### PR TITLE
Refactor mise postinstall hook

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+cask "macfuse" 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +67,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +98,7 @@ dependencies = [
 name = "git-ast"
 version = "0.1.0"
 dependencies = [
+ "fuser",
  "git2",
  "tree-sitter",
 ]
@@ -331,6 +354,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +381,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -573,6 +618,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +682,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 tree-sitter = "0.25.3"
 git2 = "0.18"
+fuser = "0.15"

--- a/README.md
+++ b/README.md
@@ -285,3 +285,21 @@ The performance trade-offs suggest some overhead, but with modern computing reso
 In practice, implementing this system would likely start with a prototype for one language (say Python or JavaScript, which Tree-sitter supports) and gradually generalize. The use of FUSE and hooking Git commands means it can be layered without modifying Git internals, which is a huge advantage. Over time, such a system could evolve from a power tool into a mainstream approach, especially as projects grow larger and the costs of mismerges and legibility issues rise.
 
 This deep analysis shows that while non-trivial, replacing text-based Git with an AST-based layer is within reach. It aligns with the software engineering trend of raising abstraction levels – here we raise version control from lines to syntax trees. The immediate next steps would be to build a proof-of-concept, measure its behavior on real repositories, and refine the design (especially around node identity and performance). If successful, it could usher in a new era of version control where the VCS truly "understands" code structure, leading to more automation and less manual conflict resolution for developers.
+
+## Setup
+
+### Prerequisites
+
+- **Rust Toolchain:** Ensure you have Rust installed. You can get it from [rustup.rs](https://rustup.rs/).
+- **Homebrew (macOS):** If you are on macOS, you will need Homebrew to install system dependencies. You can install it from [brew.sh](https://brew.sh/).
+
+### Dependencies
+
+- **macFUSE (macOS):** The AST Virtual Filesystem relies on FUSE. On macOS, you need to install macFUSE:
+  ```bash
+  brew install macfuse
+  ```
+
+Follow the post-installation instructions provided by the `brew install` command, which may involve system settings changes.
+
+*(Note: Containerized development environments using tools like Docker or Dagger are planned for the future to simplify dependency management across platforms.)*

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
 [tools]
-rust = "stable" 
+rust = "stable"
+
+[hooks]
+postinstall = './scripts/mise-postinstall.sh' 

--- a/scripts/mise-postinstall.sh
+++ b/scripts/mise-postinstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Only run on macOS
+if [ "$(uname)" != "Darwin" ]; then
+  echo "Skipping macOS dependency check on non-macOS system."
+  exit 0
+fi
+
+# Check for Homebrew
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Error: Homebrew is required on macOS but not found. Please install Homebrew (brew.sh)." >&2
+  exit 1
+fi
+
+echo "Installing Homebrew dependencies via Brewfile..."
+brew bundle install # Avoid potential lockfile issues
+
+echo "Verifying project build with dependencies..."
+cargo build
+
+echo "macOS setup verification successful!" 


### PR DESCRIPTION
Moved the postinstall hook script to scripts/mise-postinstall.sh for clarity and fixed execution error.

## Summary by Sourcery

Refactor and improve the project's macOS setup and dependency management by introducing a postinstall hook script and Brewfile

New Features:
- Added a macOS-specific postinstall hook script to manage system dependencies

Enhancements:
- Improved project setup documentation with detailed prerequisites and dependency instructions

Build:
- Created a Brewfile to manage macOS-specific dependencies
- Added fuser dependency to Cargo.toml

Documentation:
- Updated README.md with comprehensive setup instructions for macOS

Chores:
- Moved postinstall hook script to a dedicated location in the project structure