### PR TITLE
feat: structural JSON diff driver (retire the diff -u placeholder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,19 @@ The core pipeline is implemented and runs through real Git:
 - `git-ast inspect [FILE]` lists top-level definitions with a
   **formatting-invariant content hash** — a proof-of-concept of the first
   read verb (see "The interface: verbs" below).
-- **Structural 3-way merge for JSON.** `git-ast setup` also wires a real merge
-  driver ([`src/merge.rs`](./src/merge.rs)): on `git merge`, JSON is merged by
+- **Structural 3-way merge for JSON.** `git-ast setup` wires a real merge driver
+  ([`src/merge.rs`](./src/merge.rs)): on `git merge`, JSON is merged by
   **structure** — edits and additions to *different* object keys merge cleanly
   even when they touch adjacent lines (where a text merge would conflict); only a
-  genuine same-key divergence conflicts. Proven against real `git merge` by the
-  cucumber claims suite. (A machine-checked **Lean** proof of the merge's
-  soundness is the immediate follow-up — see boundaries below.)
+  genuine same-key divergence conflicts. Backed **both ways**: proven against real
+  `git merge` by the cucumber claims suite, *and* by a machine-checked **Lean**
+  proof of the merge's soundness ([`proofs/JsonMerge.lean`](./proofs/JsonMerge.lean),
+  CI-gated sorry-free).
+- **Structural diff for JSON.** The diff driver
+  ([`src/diff.rs`](./src/diff.rs)) reports a `git diff` as object-key paths that
+  were added/removed/changed (`~ a.b: 1 -> 2`, `+ c: 3`, `- d`) — *what* changed
+  semantically, order-independent — rather than text lines. Non-JSON paths fall
+  back to a unified text diff.
 
 Honest boundaries:
 
@@ -88,15 +94,16 @@ Honest boundaries:
   returns an error rather than corrupting code. Widening Rust coverage is additive
   — one more arm per node kind; adding a language is one more arm in the filter's
   per-extension dispatch.
-- **Structural merge is JSON-only, and not yet Lean-proven.** The merge driver
-  handles `*.json`; the Rust-language structural merge (over the Tree-sitter CST)
-  and array element-level merging are later increments. The merge algorithm's
-  soundness is exercised by Rust property tests now; a Lean proof (the formal
-  half of "backed by Rust *and* Lean") lands next.
-- **The diff driver is still a placeholder, and merge does not track node
-  identity.** Structural *diff*, and tracking a node through a move or
-  rename, depend on the hardest open problem — **stable AST node identity across
-  versions** — which this does **not** solve. That problem is described in
+- **Structural merge and diff are JSON-only.** Both drivers handle `*.json`; the
+  Rust-language structural merge/diff (over the Tree-sitter CST) and array
+  element-level diffing/merging are later increments. The merge is both
+  property-tested in Rust and **Lean-proven** ([`proofs/`](./proofs/README.md));
+  the diff is Rust-tested.
+- **Node identity is unsolved (the frontier).** Tracking a node through a move or
+  rename — refactor-aware history, semantic diff *beyond* canonical formatting —
+  depends on the hardest open problem, **stable AST node identity across
+  versions**, which this does **not** solve. (`git-ast inspect`'s content hash is
+  the only seam so far.) That problem is described in
   [`docs/planning/scope.md`](./docs/planning/scope.md) and remains out of scope.
 
 ## On stable node identity (the hard part)

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,189 @@
+//! Structural diff for JSON.
+//!
+//! The companion to [`crate::merge`]: where the merge *reconciles* two JSON values
+//! against a base, [`diff`] *describes* the change between two values by
+//! **structure** rather than text lines. It reports object-key paths that were
+//! added, removed, or changed — order-independent and explicit — so a `git diff`
+//! shows *what* changed semantically, not just which lines moved.
+//!
+//! Wired as Git's external diff driver for `*.json` (see [`crate::drivers`] and
+//! `git-ast setup`). Boundary (v1): arrays and differing scalars are reported as
+//! a whole-value change (no element-level diff yet) — the same one-level scope as
+//! the merge.
+
+use serde_json::Value;
+
+/// A single structural change at an object-key path (dotted, e.g. `a.b.c`; the
+/// empty path is the document root).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Change {
+    Added {
+        path: String,
+        value: Value,
+    },
+    Removed {
+        path: String,
+        value: Value,
+    },
+    Changed {
+        path: String,
+        old: Value,
+        new: Value,
+    },
+}
+
+/// Compute the structural diff from `old` to `new`.
+pub fn diff(old: &Value, new: &Value) -> Vec<Change> {
+    let mut out = Vec::new();
+    diff_into("", old, new, &mut out);
+    out
+}
+
+fn diff_into(path: &str, old: &Value, new: &Value, out: &mut Vec<Change>) {
+    if old == new {
+        return;
+    }
+    match (old, new) {
+        (Value::Object(o), Value::Object(n)) => {
+            // Union of keys, deterministically ordered (Map is a BTreeMap, so its
+            // keys already iterate sorted; merge the two sorted sets).
+            let mut keys: Vec<&String> = o.keys().chain(n.keys()).collect();
+            keys.sort_unstable();
+            keys.dedup();
+            for k in keys {
+                let child = if path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{path}.{k}")
+                };
+                match (o.get(k), n.get(k)) {
+                    (Some(ov), Some(nv)) => diff_into(&child, ov, nv, out),
+                    (None, Some(nv)) => out.push(Change::Added {
+                        path: child,
+                        value: nv.clone(),
+                    }),
+                    (Some(ov), None) => out.push(Change::Removed {
+                        path: child,
+                        value: ov.clone(),
+                    }),
+                    (None, None) => {}
+                }
+            }
+        }
+        // Differing scalars, arrays, or a type change: a whole-value change.
+        _ => out.push(Change::Changed {
+            path: path.to_string(),
+            old: old.clone(),
+            new: new.clone(),
+        }),
+    }
+}
+
+/// Render a structural diff as deterministic, human-readable text:
+/// `+ path: value` (added), `- path: value` (removed), `~ path: old -> new`.
+pub fn render(changes: &[Change]) -> String {
+    let mut s = String::new();
+    for c in changes {
+        match c {
+            Change::Added { path, value } => {
+                s.push_str(&format!("+ {}: {}\n", label(path), compact(value)));
+            }
+            Change::Removed { path, value } => {
+                s.push_str(&format!("- {}: {}\n", label(path), compact(value)));
+            }
+            Change::Changed { path, old, new } => {
+                s.push_str(&format!(
+                    "~ {}: {} -> {}\n",
+                    label(path),
+                    compact(old),
+                    compact(new)
+                ));
+            }
+        }
+    }
+    s
+}
+
+fn label(path: &str) -> &str {
+    if path.is_empty() {
+        "(root)"
+    } else {
+        path
+    }
+}
+
+/// Compact one-line rendering of a value (for the diff lines).
+fn compact(v: &Value) -> String {
+    serde_json::to_string(v).unwrap_or_else(|_| "<unrenderable>".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn rendered(old: Value, new: Value) -> String {
+        render(&diff(&old, &new))
+    }
+
+    #[test]
+    fn no_change_is_empty() {
+        assert_eq!(diff(&json!({"a": 1}), &json!({"a": 1})), vec![]);
+    }
+
+    #[test]
+    fn changed_scalar_at_key() {
+        assert_eq!(rendered(json!({"a": 1}), json!({"a": 2})), "~ a: 1 -> 2\n");
+    }
+
+    #[test]
+    fn added_and_removed_keys() {
+        // ordered by key; only the actual changes appear.
+        assert_eq!(
+            rendered(json!({"a": 1, "b": 2}), json!({"a": 1, "c": 3})),
+            "- b: 2\n+ c: 3\n"
+        );
+    }
+
+    #[test]
+    fn nested_path_is_dotted() {
+        assert_eq!(
+            rendered(
+                json!({"o": {"x": 1, "y": 1}}),
+                json!({"o": {"x": 2, "y": 1}})
+            ),
+            "~ o.x: 1 -> 2\n"
+        );
+    }
+
+    #[test]
+    fn key_reorder_is_no_diff() {
+        // Structure, not text: reordering keys produces no change.
+        assert_eq!(
+            diff(&json!({"a": 1, "b": 2}), &json!({"b": 2, "a": 1})),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn array_change_is_whole_value() {
+        // v1 boundary: arrays diff as a whole value.
+        assert_eq!(
+            rendered(json!({"a": [1, 2]}), json!({"a": [1, 2, 3]})),
+            "~ a: [1,2] -> [1,2,3]\n"
+        );
+    }
+
+    #[test]
+    fn root_scalar_change() {
+        assert_eq!(rendered(json!(1), json!(2)), "~ (root): 1 -> 2\n");
+    }
+
+    #[test]
+    fn type_change_at_key() {
+        assert_eq!(
+            rendered(json!({"a": 1}), json!({"a": "x"})),
+            "~ a: 1 -> \"x\"\n"
+        );
+    }
+}

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -3,12 +3,14 @@
 //! The **merge driver** performs a real structural 3-way merge for `*.json`
 //! (see [`crate::merge`]): it parses base/ours/theirs, merges by structure, and
 //! writes the canonical merged JSON on a clean merge — falling back to standard
-//! conflict markers (and a non-zero exit) on a genuine conflict. Other paths keep
-//! the conflict-marker placeholder. The **diff driver** is still a placeholder
-//! (shells out to `diff -u`).
+//! conflict markers (and a non-zero exit) on a genuine conflict.
+//!
+//! The **diff driver** renders a structural diff for `*.json` (see [`crate::diff`]):
+//! object-key paths that were added/removed/changed, rather than text lines. Other
+//! paths fall back to a unified text diff (`diff -u`).
 
 use crate::merge::Merge3;
-use crate::{json, merge, Error};
+use crate::{diff, json, merge, Error};
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
@@ -18,7 +20,8 @@ use std::process::Command;
 /// Git invokes `GIT_EXTERNAL_DIFF`-style with 7 args:
 /// `path old-file old-hex old-mode new-file new-hex new-mode`.
 ///
-/// Placeholder: emits a unified text diff of the two files on stdout.
+/// For `*.json` (when both versions parse), prints a structural diff. Otherwise
+/// emits a unified text diff of the two files.
 pub fn run_diff_driver(args: &[String]) -> Result<(), Error> {
     if args.len() < 7 {
         return Err(Error::Driver(
@@ -26,16 +29,33 @@ pub fn run_diff_driver(args: &[String]) -> Result<(), Error> {
         ));
     }
     let (path, old_file, new_file) = (&args[0], &args[1], &args[4]);
-    eprintln!("[diff] {path}: {old_file} -> {new_file} (placeholder: text diff)");
 
+    if path.ends_with(".json") {
+        if let Some(text) = try_json_diff(old_file, new_file) {
+            std::io::stdout().write_all(text.as_bytes())?;
+            return Ok(());
+        }
+    }
+    text_diff(old_file, new_file)
+}
+
+/// Structural JSON diff of two files. Returns `None` if either file is not valid
+/// JSON (e.g. `/dev/null` for a created/deleted file), so the caller falls back.
+fn try_json_diff(old_file: &str, new_file: &str) -> Option<String> {
+    let old: serde_json::Value = serde_json::from_slice(&std::fs::read(old_file).ok()?).ok()?;
+    let new: serde_json::Value = serde_json::from_slice(&std::fs::read(new_file).ok()?).ok()?;
+    Some(diff::render(&diff::diff(&old, &new)))
+}
+
+/// Fallback unified text diff. `diff` exits 0 (identical) or 1 (differing); both
+/// are success here.
+fn text_diff(old_file: &str, new_file: &str) -> Result<(), Error> {
     let output = Command::new("diff")
         .arg("-u")
         .arg(old_file)
         .arg(new_file)
         .output()?;
     std::io::stdout().write_all(&output.stdout)?;
-
-    // `diff` exits 0 when identical and 1 when differing; both are success here.
     match output.status.code() {
         Some(0) | Some(1) => Ok(()),
         _ => Err(Error::Driver(format!("`diff` failed: {:?}", output.status))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! Configuration is read via [`config`].
 
 pub mod config;
+pub mod diff;
 pub mod drivers;
 pub mod filters;
 pub mod json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,13 +74,13 @@ fn print_help() {
          setup             Enable the *.rs and *.json clean/smudge filter here\n    \
          inspect [FILE]    List top-level defs with a formatting-invariant hash\n    \
          filter-process    Clean/smudge long-running filter (Rust + JSON)\n    \
-         diff-driver       Git diff driver (placeholder)\n    \
-         merge-driver      Git merge driver (placeholder)\n    \
+         diff-driver       Structural diff (JSON); text diff otherwise\n    \
+         merge-driver      Structural 3-way merge (JSON)\n    \
          --version, -V     Print version\n    \
          --help, -h        Print this help\n\
          \n\
          The clean/smudge round-trip canonicalizes JSON and a documented Rust\n\
-         subset, and is fail-closed outside it. Structural diff/merge await stable\n\
-         node identity; see docs/ for the design and scope."
+         subset; structural merge & diff are real for JSON. Refactor-aware history\n\
+         (node identity) is the remaining frontier; see docs/ for the design."
     );
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -18,6 +18,7 @@ const ATTR_LINES: &[&str] = &[
     "*.rs filter=git-ast",
     "*.json filter=git-ast",
     "*.json merge=git-ast",
+    "*.json diff=git-ast",
 ];
 
 /// Configure the current repository to use git-ast for the supported languages.
@@ -40,9 +41,12 @@ pub fn run() -> Result<(), Error> {
         &format!("{exe} merge-driver %O %A %B %L %P"),
     )?;
 
+    // Structural diff driver (JSON). Git appends the GIT_EXTERNAL_DIFF args.
+    git_config("diff.git-ast.command", &format!("{exe} diff-driver"))?;
+
     ensure_attributes()?;
 
-    eprintln!("git-ast: configured filter (*.rs, *.json) + structural merge (*.json).");
+    eprintln!("git-ast: configured filter (*.rs, *.json) + structural merge & diff (*.json).");
     eprintln!("git-ast: re-add existing files to canonicalize them: git add --renormalize .");
     Ok(())
 }

--- a/tests/claims.rs
+++ b/tests/claims.rs
@@ -79,9 +79,15 @@ async fn install(world: &mut AstWorld) {
         "merge.git-ast.driver",
         &format!("{bin} merge-driver %O %A %B %L %P"),
     ]);
+    // Structural diff driver (JSON).
+    run(&[
+        "config",
+        "diff.git-ast.command",
+        &format!("{bin} diff-driver"),
+    ]);
     std::fs::write(
         dir.join(".gitattributes"),
-        "*.rs filter=git-ast\n*.json filter=git-ast\n*.json merge=git-ast\n",
+        "*.rs filter=git-ast\n*.json filter=git-ast\n*.json merge=git-ast\n*.json diff=git-ast\n",
     )
     .expect("write attrs");
     world.repo = Some(repo);
@@ -181,6 +187,15 @@ async fn merge_succeeds(world: &mut AstWorld) {
 #[then("the merge conflicts")]
 async fn merge_conflicts(world: &mut AstWorld) {
     assert_ne!(world.last_merge_code, 0, "expected a merge conflict");
+}
+
+#[then(expr = "the diff of {string} contains {string}")]
+async fn diff_contains(world: &mut AstWorld, name: String, needle: String) {
+    let (_, out) = world.git(&["diff", "--", &name]);
+    assert!(
+        out.contains(&needle),
+        "expected diff of {name} to contain `{needle}`, got:\n{out}"
+    );
 }
 
 #[tokio::main]

--- a/tests/features/claims.feature
+++ b/tests/features/claims.feature
@@ -171,6 +171,20 @@ Feature: git-ast canonical clean/smudge round-trip
       }
       """
 
+  Scenario: Structural diff — git diff reports key-path changes
+    When I stage "config.json" containing:
+      """
+      { "a": 1, "b": 2 }
+      """
+    And I commit
+    And I overwrite "config.json" with:
+      """
+      { "a": 9, "c": 3 }
+      """
+    Then the diff of "config.json" contains "~ a: 1 -> 9"
+    And the diff of "config.json" contains "- b: 2"
+    And the diff of "config.json" contains "+ c: 3"
+
   Scenario: Structural merge — same key diverging is a conflict
     When I stage "config.json" containing:
       """


### PR DESCRIPTION
## Summary

Replaces the diff-driver placeholder with a **real structural diff for JSON** — the *diff* half of trust **8.1c**. On `git diff`, JSON changes are reported as **object-key paths** (added/removed/changed), order-independent, rather than text lines.

```
~ a: 1 -> 9
- b: 2
+ c: 3
~ nested.x: 1 -> 5
```

- **`src/diff.rs`** — `diff(old, new) -> Vec<Change>` over `serde_json::Value` (recurse per key; arrays/scalars are whole-value changes — same one-level scope as the merge). Deterministic `render()`.
- **`src/drivers.rs`** — `run_diff_driver` dispatches `*.json` to the structural diff; falls back to `diff -u` for non-JSON / unparseable / created-deleted files.
- **`src/setup.rs`** — registers `diff.git-ast.command` + routes `*.json diff=git-ast`.

## Tests — all green (58 unit + 15 scenarios/87 steps + 5 merge)
- 8 `diff.rs` unit tests (changed/added/removed, nested dotted paths, **key reorder = no diff**, array whole-value, root scalar, type change)
- cucumber scenario driving **real `git diff`** — asserts structural output

Also refreshes the README (the Lean proof is *merged*, not 'forthcoming'; node identity is the remaining frontier).

## Trust ledger
Advances **8.1c 📐 → 🟡**: the structural *diff* is built and real-git-verified. Still 📐-worthy remainder: **node identity** (move/rename tracking) — the genuine research problem.

## Out of scope
Rust-language diff, array element-level diff, and **node identity** — 8.1c's frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)