### PR TITLE
feat: node identity (first slice) — content-addressed def matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ The core pipeline is implemented and runs through real Git:
 - `git-ast inspect [FILE]` lists top-level definitions with a
   **formatting-invariant content hash** — a proof-of-concept of the first
   read verb (see "The interface: verbs" below).
+- **Node identity (first slice).** `git-ast match <old> <new>`
+  ([`src/identity.rs`](./src/identity.rs)) corresponds top-level functions across
+  two versions via content-addressed hashing — tracking a function through a
+  **rename** (`renamed parse -> deserialize`), a **reorder** (`unchanged`), or a
+  **body edit** (`modified`), plus `added`/`removed`. These are the *exact*,
+  zero-heuristic matches; **fuzzy** matching is the remaining frontier (below).
 - **Structural 3-way merge for JSON.** `git-ast setup` wires a real merge driver
   ([`src/merge.rs`](./src/merge.rs)): on `git merge`, JSON is merged by
   **structure** — edits and additions to *different* object keys merge cleanly
@@ -99,12 +105,15 @@ Honest boundaries:
   element-level diffing/merging are later increments. The merge is both
   property-tested in Rust and **Lean-proven** ([`proofs/`](./proofs/README.md));
   the diff is Rust-tested.
-- **Node identity is unsolved (the frontier).** Tracking a node through a move or
-  rename — refactor-aware history, semantic diff *beyond* canonical formatting —
-  depends on the hardest open problem, **stable AST node identity across
-  versions**, which this does **not** solve. (`git-ast inspect`'s content hash is
-  the only seam so far.) That problem is described in
-  [`docs/planning/scope.md`](./docs/planning/scope.md) and remains out of scope.
+- **Node identity: exact matching works; fuzzy matching is the frontier.**
+  `git-ast match` recognizes a function across a rename, reorder, or body edit by
+  content-addressed hashing (the *exact*, zero-heuristic matches — the README's
+  "by matching" family). What it does **not** yet do is the hard part: **fuzzy**
+  matching (a node renamed *and* edited at once, GumTree-family), the deeper
+  identity axes (deep/Merkle content, binding identity via name resolution,
+  use-site identity), non-`fn` items, cross-file matching, and persisting
+  attribution (git notes). Those — refactor-aware blame in full — remain the open
+  research problem described in [`docs/planning/scope.md`](./docs/planning/scope.md).
 
 ## On stable node identity (the hard part)
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,250 @@
+//! Node identity: matching top-level definitions across two versions.
+//!
+//! The first slice of the hardest open problem (see the node-identity essay in
+//! the README). The **lever** is content-addressed hashing: a definition's
+//! formatting-invariant hashes ([`crate::printer::Def`]) let us recognize *the
+//! same node* across an edit — for free, with no heuristics:
+//!
+//! - **content_hash** (name + body) equal → the node is **unchanged**. Position
+//!   is ignored, so reordering top-level definitions is *not* a change.
+//! - **name** equal but content differs → the node is the **same** (a body edit).
+//! - **shape_hash** (body, declared name blanked) equal → a **rename** (same body,
+//!   new name).
+//!
+//! [`match_defs`] layers these strongest-first. What it deliberately does *not*
+//! do is **fuzzy** matching — a node renamed *and* edited at once — which needs
+//! GumTree-family matching and is the genuinely hard remainder of node identity.
+
+use crate::printer::Def;
+
+/// How a definition corresponds across two versions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Correspondence {
+    /// Same name and body (content-identical; position ignored).
+    Unchanged { name: String },
+    /// Same body, different name.
+    Renamed { from: String, to: String },
+    /// Same name, different body.
+    Modified { name: String },
+    /// Present only in the new version.
+    Added { name: String },
+    /// Present only in the old version.
+    Removed { name: String },
+}
+
+/// Match the definitions of two versions, strongest signal first. Each match
+/// consumes one def from each side; remaining defs are added/removed.
+pub fn match_defs(old: &[Def], new: &[Def]) -> Vec<Correspondence> {
+    let mut old_used = vec![false; old.len()];
+    let mut new_used = vec![false; new.len()];
+    let mut out = Vec::new();
+
+    // Find the first unused `new` def satisfying `pred`.
+    let first_new = |new_used: &[bool], pred: &dyn Fn(&Def) -> bool| -> Option<usize> {
+        new.iter()
+            .enumerate()
+            .find(|(nj, n)| !new_used[*nj] && pred(n))
+            .map(|(nj, _)| nj)
+    };
+
+    // Pass 1: content_hash equal → Unchanged (exact; position-independent).
+    for (oi, o) in old.iter().enumerate() {
+        if let Some(ni) = first_new(&new_used, &|n| n.content_hash == o.content_hash) {
+            old_used[oi] = true;
+            new_used[ni] = true;
+            out.push(Correspondence::Unchanged {
+                name: new[ni].name.clone(),
+            });
+        }
+    }
+    // Pass 2: same name, different body → Modified.
+    for (oi, o) in old.iter().enumerate() {
+        if old_used[oi] {
+            continue;
+        }
+        if let Some(ni) = first_new(&new_used, &|n| n.name == o.name) {
+            old_used[oi] = true;
+            new_used[ni] = true;
+            out.push(Correspondence::Modified {
+                name: o.name.clone(),
+            });
+        }
+    }
+    // Pass 3: same body, different name → Renamed (exact).
+    for (oi, o) in old.iter().enumerate() {
+        if old_used[oi] {
+            continue;
+        }
+        if let Some(ni) = first_new(&new_used, &|n| n.shape_hash == o.shape_hash) {
+            old_used[oi] = true;
+            new_used[ni] = true;
+            out.push(Correspondence::Renamed {
+                from: o.name.clone(),
+                to: new[ni].name.clone(),
+            });
+        }
+    }
+    // Leftovers.
+    for (oi, o) in old.iter().enumerate() {
+        if !old_used[oi] {
+            out.push(Correspondence::Removed {
+                name: o.name.clone(),
+            });
+        }
+    }
+    for (ni, n) in new.iter().enumerate() {
+        if !new_used[ni] {
+            out.push(Correspondence::Added {
+                name: n.name.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// Render correspondences as deterministic, human-readable lines.
+pub fn render(cs: &[Correspondence]) -> String {
+    let mut s = String::new();
+    for c in cs {
+        match c {
+            Correspondence::Unchanged { name } => s.push_str(&format!("unchanged  {name}\n")),
+            Correspondence::Renamed { from, to } => {
+                s.push_str(&format!("renamed    {from} -> {to}\n"))
+            }
+            Correspondence::Modified { name } => s.push_str(&format!("modified   {name}\n")),
+            Correspondence::Added { name } => s.push_str(&format!("added      {name}\n")),
+            Correspondence::Removed { name } => s.push_str(&format!("removed    {name}\n")),
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::printer::inspect;
+
+    fn defs(src: &str) -> Vec<Def> {
+        inspect(src.as_bytes()).unwrap()
+    }
+
+    fn matched(old: &str, new: &str) -> Vec<Correspondence> {
+        match_defs(&defs(old), &defs(new))
+    }
+
+    #[test]
+    fn unchanged_even_when_reordered() {
+        // Same two fns, reversed order, reformatted → both Unchanged (no Moved).
+        let cs = matched(
+            "fn a()->i32{1}\nfn b()->i32{2}",
+            "fn b() -> i32 {\n    2\n}\nfn a()->i32{1}",
+        );
+        assert_eq!(
+            cs,
+            vec![
+                Correspondence::Unchanged { name: "a".into() },
+                Correspondence::Unchanged { name: "b".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn rename_with_unchanged_body() {
+        let cs = matched(
+            "fn oldName(x: i32) -> i32 { x + 1 }",
+            "fn newName(x: i32) -> i32 { x + 1 }",
+        );
+        assert_eq!(
+            cs,
+            vec![Correspondence::Renamed {
+                from: "oldName".into(),
+                to: "newName".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn same_name_edited_body_is_modified() {
+        let cs = matched("fn f() -> i32 { 1 }", "fn f() -> i32 { 2 }");
+        assert_eq!(cs, vec![Correspondence::Modified { name: "f".into() }]);
+    }
+
+    #[test]
+    fn added_and_removed() {
+        let cs = matched("fn gone() -> i32 { 1 }", "fn fresh() -> i32 { 9 }");
+        assert_eq!(
+            cs,
+            vec![
+                Correspondence::Removed {
+                    name: "gone".into()
+                },
+                Correspondence::Added {
+                    name: "fresh".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn mixed_change_set() {
+        let cs = matched(
+            "fn keep()->i32{1}\nfn edit()->i32{2}\nfn old()->i32{3}\nfn drop()->i32{4}",
+            "fn keep()->i32{1}\nfn edit()->i32{9}\nfn renamed()->i32{3}\nfn brand()->i32{5}",
+        );
+        assert_eq!(
+            cs,
+            vec![
+                Correspondence::Unchanged {
+                    name: "keep".into()
+                },
+                Correspondence::Modified {
+                    name: "edit".into()
+                },
+                Correspondence::Renamed {
+                    from: "old".into(),
+                    to: "renamed".into()
+                },
+                Correspondence::Removed {
+                    name: "drop".into()
+                },
+                Correspondence::Added {
+                    name: "brand".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn name_match_wins_over_rename_when_ambiguous() {
+        // old foo(1); new foo(2) + bar(1). foo stays foo (Modified), bar is Added
+        // — name-stability beats the body-shape rename signal.
+        let cs = matched("fn foo()->i32{1}", "fn foo()->i32{2}\nfn bar()->i32{1}");
+        assert_eq!(
+            cs,
+            vec![
+                Correspondence::Modified { name: "foo".into() },
+                Correspondence::Added { name: "bar".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn recursive_rename_reads_as_modified_or_removed() {
+        // Documented limitation: a recursive body references the old name, so
+        // blanking only the declaration does not make the shapes match. The fn
+        // is not recognized as a rename.
+        let cs = matched(
+            "fn fac(n: i32) -> i32 { fac(n) }",
+            "fn factorial(n: i32) -> i32 { factorial(n) }",
+        );
+        assert_eq!(
+            cs,
+            vec![
+                Correspondence::Removed { name: "fac".into() },
+                Correspondence::Added {
+                    name: "factorial".into()
+                },
+            ]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod config;
 pub mod diff;
 pub mod drivers;
 pub mod filters;
+pub mod identity;
 pub mod json;
 pub mod merge;
 pub mod pktline;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 use std::io::Read;
 use std::process::ExitCode;
 
-use git_ast::{drivers, filters, printer, setup, Error};
+use git_ast::{drivers, filters, identity, printer, setup, Error};
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -19,6 +19,7 @@ fn main() -> ExitCode {
     let result = match cmd.as_str() {
         "setup" => setup::run().map(|()| 0u8),
         "inspect" => run_inspect(rest),
+        "match" => run_match(rest),
         "filter-process" => filters::run_long_running_filter().map(|()| 0u8),
         "diff-driver" => drivers::run_diff_driver(rest).map(|()| 0u8),
         "merge-driver" => drivers::run_merge_driver(rest).map(|()| 0u8),
@@ -63,6 +64,21 @@ fn run_inspect(args: &[String]) -> Result<u8, Error> {
     Ok(0)
 }
 
+/// The `match` read verb: correspond top-level definitions across two versions
+/// (`git-ast match <old> <new>`), reporting each as unchanged / renamed /
+/// modified / added / removed via content-addressed identity.
+fn run_match(args: &[String]) -> Result<u8, Error> {
+    let (Some(old_path), Some(new_path)) = (args.first(), args.get(1)) else {
+        return Err(Error::Config(
+            "match expects two file arguments: git-ast match <old> <new>".to_string(),
+        ));
+    };
+    let old = printer::inspect(&std::fs::read(old_path)?)?;
+    let new = printer::inspect(&std::fs::read(new_path)?)?;
+    print!("{}", identity::render(&identity::match_defs(&old, &new)));
+    Ok(0)
+}
+
 fn print_help() {
     eprintln!(
         "git-ast — language-aware Git\n\
@@ -73,6 +89,7 @@ fn print_help() {
          SUBCOMMANDS:\n    \
          setup             Enable the *.rs and *.json clean/smudge filter here\n    \
          inspect [FILE]    List top-level defs with a formatting-invariant hash\n    \
+         match OLD NEW     Correspond defs across two versions (rename/move/edit)\n    \
          filter-process    Clean/smudge long-running filter (Rust + JSON)\n    \
          diff-driver       Structural diff (JSON); text diff otherwise\n    \
          merge-driver      Structural 3-way merge (JSON)\n    \

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -87,10 +87,16 @@ pub struct Def {
     /// The declared name.
     pub name: String,
     /// Content identity: a deterministic hash of the node's *canonical* form,
-    /// so it is **stable across reformatting**. Note this hash couples name and
-    /// body — separating the pure-content axis (alpha-normalizing the name) is
-    /// the refinement described under "Identity is a vector" in the README.
+    /// so it is **stable across reformatting**. Couples name *and* body — two
+    /// functions match here only if both are identical.
     pub content_hash: String,
+    /// Shape identity: the same hash with the function's *declared name* blanked
+    /// (the "shallow content" axis from the README). Two functions with identical
+    /// bodies but different names share a `shape_hash` — the seam that lets
+    /// [`crate::identity`] recognize a **rename**. (v1 normalizes only the
+    /// declaration; a recursive body still references the old name, so a recursive
+    /// rename reads as a body edit, not a rename.)
+    pub shape_hash: String,
 }
 
 /// The first **verbspec read verb** — "look at the AST."
@@ -122,10 +128,15 @@ pub fn inspect(source: &[u8]) -> Result<Vec<Def>, Error> {
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("?")
             .to_string();
+        // Shape hash: blank the declared name (the canonical form always begins
+        // `fn <name>(`), so two bodies that differ only by name share it.
+        let canonical = &printer.out;
+        let shaped = canonical.replacen(&format!("fn {name}("), "fn _(", 1);
         defs.push(Def {
             kind: "fn",
             name,
-            content_hash: fnv1a_hex(printer.out.as_bytes()),
+            content_hash: fnv1a_hex(canonical.as_bytes()),
+            shape_hash: fnv1a_hex(shaped.as_bytes()),
         });
     }
     Ok(defs)
@@ -774,6 +785,18 @@ mod tests {
         let defs = inspect(b"fn a()->i32{1+2}\nfn b()->i32{1-2}").unwrap();
         assert_eq!(defs.iter().map(|d| &d.name).collect::<Vec<_>>(), ["a", "b"]);
         assert_ne!(defs[0].content_hash, defs[1].content_hash);
+    }
+
+    #[test]
+    fn shape_hash_is_name_invariant_but_body_sensitive() {
+        // Same body, different name → same shape_hash, different content_hash.
+        let a = &inspect(b"fn a(x: i32) -> i32 { x + 1 }").unwrap()[0];
+        let b = &inspect(b"fn b(x: i32) -> i32 { x + 1 }").unwrap()[0];
+        assert_eq!(a.shape_hash, b.shape_hash, "name must not affect shape");
+        assert_ne!(a.content_hash, b.content_hash, "name must affect content");
+        // Same name, different body → different shape_hash.
+        let c = &inspect(b"fn a(x: i32) -> i32 { x + 2 }").unwrap()[0];
+        assert_ne!(a.shape_hash, c.shape_hash, "body must affect shape");
     }
 
     #[test]

--- a/tests/identity_cli.rs
+++ b/tests/identity_cli.rs
@@ -1,0 +1,43 @@
+//! End-to-end test of the `git-ast match` verb (node identity) via the binary.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_git-ast");
+
+fn run_match(old: &str, new: &str) -> String {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("match_cli");
+    fs::create_dir_all(&dir).unwrap();
+    let old_path = dir.join("old.rs");
+    let new_path = dir.join("new.rs");
+    fs::write(&old_path, old).unwrap();
+    fs::write(&new_path, new).unwrap();
+    let out = Command::new(BIN)
+        .arg("match")
+        .arg(&old_path)
+        .arg(&new_path)
+        .output()
+        .expect("run git-ast match");
+    assert!(
+        out.status.success(),
+        "match failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap()
+}
+
+#[test]
+fn match_verb_tracks_rename_modify_add_remove() {
+    let old = "fn keep()->i32{1}\nfn edit()->i32{2}\nfn renameMe()->i32{3}\nfn drop()->i32{4}";
+    let new = "fn keep()->i32{1}\nfn edit()->i32{99}\nfn renamed()->i32{3}\nfn fresh()->i32{5}";
+    let out = run_match(old, new);
+    assert!(out.contains("unchanged  keep"), "got:\n{out}");
+    assert!(out.contains("modified   edit"), "got:\n{out}");
+    assert!(
+        out.contains("renamed    renameMe -> renamed"),
+        "got:\n{out}"
+    );
+    assert!(out.contains("removed    drop"), "got:\n{out}");
+    assert!(out.contains("added      fresh"), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

The first real slice of git-ast's hardest open problem (trust **8.1d**). `git-ast match <old> <new>` corresponds top-level Rust functions across two versions by **content-addressed hashing** — tracking a function through a **rename**, a **reorder**, or a **body edit**:

```
unchanged  helper          # reordered — content-identical, position ignored
modified   compute         # same name, edited body
renamed    parse -> deserialize   # same body, new name
removed    gone
added      brand
```

These are the *exact*, zero-heuristic matches from the README's "by matching" family — the only family that scales.

- **`src/printer.rs`** — adds `shape_hash` to `Def`: the content hash with the *declared name blanked* (the "shallow content" axis the `Def` doc already flagged as the next refinement). Two bodies that differ only by name share it → the seam for rename detection.
- **`src/identity.rs`** — `match_defs` returns `Unchanged | Renamed | Modified | Added | Removed`, layered strongest-first: content_hash → name → shape_hash → leftovers.
- **`src/main.rs`** — new `match` read verb.

## Tests — all green (66 unit + 15 cucumber/87 steps + 1 identity e2e + 5 merge)
- 7 identity unit tests (reorder=unchanged, rename, modify, add/remove, mixed set, name-wins-ambiguity, **recursive-rename limitation**)
- `shape_hash` property test (name-invariant + body-sensitive)
- `tests/identity_cli.rs` — the real `git-ast match` binary

## Honest scope
Exact matching only. **Out of scope (8.1d's remaining frontier):** fuzzy matching (a node renamed *and* edited at once — GumTree-family), deep/Merkle content, binding identity (name resolution), use-site identity, non-`fn` items, cross-file matching, and persistence (git notes).

## Trust ledger
Advances **8.1d 📐 → 🟡**: exact content-addressed node matching for top-level Rust fns, real-CLI-verified. Full ✅ awaits fuzzy matching + the deeper identity axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)