### PR TITLE
feat: fuzzy node matching — track a function renamed AND edited

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@ The core pipeline is implemented and runs through real Git:
 - `git-ast inspect [FILE]` lists top-level definitions with a
   **formatting-invariant content hash** — a proof-of-concept of the first
   read verb (see "The interface: verbs" below).
-- **Node identity (first slice).** `git-ast match <old> <new>`
+- **Node identity.** `git-ast match <old> <new>`
   ([`src/identity.rs`](./src/identity.rs)) corresponds top-level functions across
-  two versions via content-addressed hashing — tracking a function through a
-  **rename** (`renamed parse -> deserialize`), a **reorder** (`unchanged`), or a
-  **body edit** (`modified`), plus `added`/`removed`. These are the *exact*,
-  zero-heuristic matches; **fuzzy** matching is the remaining frontier (below).
+  two versions. Exact, content-addressed matches first — a function tracked
+  through a **rename** (`renamed parse -> deserialize`), a **reorder**
+  (`unchanged`), or a **body edit** (`modified`), plus `added`/`removed`. Then a
+  **fuzzy** pass catches the hard case — a function **renamed *and* edited at
+  once** (`renamed+ parseConfig -> loadSettings (96% similar)`) — by Sørensen–Dice
+  similarity over the bodies. Full structural (GumTree-style) matching is the
+  remaining frontier (below).
 - **Structural 3-way merge for JSON.** `git-ast setup` wires a real merge driver
   ([`src/merge.rs`](./src/merge.rs)): on `git merge`, JSON is merged by
   **structure** — edits and additions to *different* object keys merge cleanly
@@ -105,15 +108,18 @@ Honest boundaries:
   element-level diffing/merging are later increments. The merge is both
   property-tested in Rust and **Lean-proven** ([`proofs/`](./proofs/README.md));
   the diff is Rust-tested.
-- **Node identity: exact matching works; fuzzy matching is the frontier.**
-  `git-ast match` recognizes a function across a rename, reorder, or body edit by
-  content-addressed hashing (the *exact*, zero-heuristic matches — the README's
-  "by matching" family). What it does **not** yet do is the hard part: **fuzzy**
-  matching (a node renamed *and* edited at once, GumTree-family), the deeper
-  identity axes (deep/Merkle content, binding identity via name resolution,
-  use-site identity), non-`fn` items, cross-file matching, and persisting
-  attribution (git notes). Those — refactor-aware blame in full — remain the open
-  research problem described in [`docs/planning/scope.md`](./docs/planning/scope.md).
+- **Node identity: matching works (exact + lightweight fuzzy); structural fuzzy
+  and the deeper axes remain.** `git-ast match` recognizes a function across a
+  rename, reorder, or body edit (exact, content-addressed) *and* across a
+  simultaneous rename-and-edit (fuzzy, via body string-similarity). What it does
+  **not** yet do: **structural** fuzzy matching (a real GumTree tree-edit script,
+  rather than string similarity over the canonical body), the deeper identity axes
+  (deep/Merkle content, binding identity via name resolution, use-site identity),
+  non-`fn` items, cross-file matching, and persisting attribution (git notes).
+  Those — refactor-aware blame in full — remain the open research problem described
+  in [`docs/planning/scope.md`](./docs/planning/scope.md). Note the fuzzy match is a
+  heuristic with a similarity threshold; very small functions are noisier (less
+  body to compare).
 
 ## On stable node identity (the hard part)
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -11,9 +11,13 @@
 //! - **shape_hash** (body, declared name blanked) equal → a **rename** (same body,
 //!   new name).
 //!
-//! [`match_defs`] layers these strongest-first. What it deliberately does *not*
-//! do is **fuzzy** matching — a node renamed *and* edited at once — which needs
-//! GumTree-family matching and is the genuinely hard remainder of node identity.
+//! [`match_defs`] layers these strongest-first, then adds a **fuzzy** final pass:
+//! leftover defs (a different name *and* a different body) are scored by
+//! Sørensen–Dice similarity over their name-blanked bodies and paired greedily
+//! above a threshold — recognizing a function that was **renamed and edited at
+//! once**. This is the lightweight cousin of GumTree-family matching (string
+//! similarity, not a tree edit script); full structural fuzzy matching remains
+//! the deeper frontier.
 
 use crate::printer::Def;
 
@@ -24,6 +28,14 @@ pub enum Correspondence {
     Unchanged { name: String },
     /// Same body, different name.
     Renamed { from: String, to: String },
+    /// Renamed *and* edited: a different name and a different body, but bodies
+    /// similar enough (fuzzy match) to be the same node. `similarity` is a Dice
+    /// percentage (0–100) over the name-blanked bodies.
+    RenamedEdited {
+        from: String,
+        to: String,
+        similarity: u8,
+    },
     /// Same name, different body.
     Modified { name: String },
     /// Present only in the new version.
@@ -84,6 +96,48 @@ pub fn match_defs(old: &[Def], new: &[Def]) -> Vec<Correspondence> {
             });
         }
     }
+    // Pass 4 (fuzzy): leftover defs paired by body similarity → RenamedEdited.
+    // Rank all cross pairs above the threshold by similarity (desc), then assign
+    // greedily so each def is matched at most once. Deterministic tie-breaks.
+    let leftover = |used: &[bool]| (0..used.len()).filter(|i| !used[*i]).collect::<Vec<_>>();
+    let mut ranked: Vec<(f64, usize, usize)> = Vec::new();
+    for &oi in &leftover(&old_used) {
+        for &ni in &leftover(&new_used) {
+            // Compare *bodies* (post-signature), so short functions are not
+            // matched on shared `fn _(…) -> … {` boilerplate.
+            let s = dice(
+                body_of(&old[oi].shape_source),
+                body_of(&new[ni].shape_source),
+            );
+            if s >= SIMILARITY_THRESHOLD {
+                ranked.push((s, oi, ni));
+            }
+        }
+    }
+    ranked.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap()
+            .then(a.1.cmp(&b.1))
+            .then(a.2.cmp(&b.2))
+    });
+    let mut fuzzy: Vec<(usize, usize, f64)> = Vec::new();
+    for (s, oi, ni) in ranked {
+        if old_used[oi] || new_used[ni] {
+            continue;
+        }
+        old_used[oi] = true;
+        new_used[ni] = true;
+        fuzzy.push((oi, ni, s));
+    }
+    fuzzy.sort_by_key(|&(oi, _, _)| oi);
+    for (oi, ni, s) in fuzzy {
+        out.push(Correspondence::RenamedEdited {
+            from: old[oi].name.clone(),
+            to: new[ni].name.clone(),
+            similarity: (s * 100.0).round() as u8,
+        });
+    }
+
     // Leftovers.
     for (oi, o) in old.iter().enumerate() {
         if !old_used[oi] {
@@ -102,6 +156,46 @@ pub fn match_defs(old: &[Def], new: &[Def]) -> Vec<Correspondence> {
     out
 }
 
+/// Minimum Dice similarity (0–1) over name-blanked bodies for a fuzzy match.
+/// Above this, two differently-named, differently-bodied functions are treated
+/// as the same node renamed-and-edited; below it, they are add/remove.
+const SIMILARITY_THRESHOLD: f64 = 0.5;
+
+/// The function body: from the first `{` onward (signature stripped). Falls back
+/// to the whole string if there is no brace.
+fn body_of(shape: &str) -> &str {
+    match shape.find('{') {
+        Some(i) => &shape[i..],
+        None => shape,
+    }
+}
+
+/// Sørensen–Dice coefficient over character bigrams: `2·|A∩B| / (|A|+|B|)`,
+/// a dependency-free string similarity in `[0, 1]`.
+fn dice(a: &str, b: &str) -> f64 {
+    let bigrams = |s: &str| -> Vec<(char, char)> {
+        let chars: Vec<char> = s.chars().collect();
+        chars.windows(2).map(|w| (w[0], w[1])).collect()
+    };
+    let (ba, bb) = (bigrams(a), bigrams(b));
+    if ba.is_empty() || bb.is_empty() {
+        return if ba.len() == bb.len() { 1.0 } else { 0.0 };
+    }
+    let mut counts: std::collections::HashMap<(char, char), i32> = std::collections::HashMap::new();
+    for g in &ba {
+        *counts.entry(*g).or_insert(0) += 1;
+    }
+    let mut inter = 0usize;
+    for g in &bb {
+        let c = counts.entry(*g).or_insert(0);
+        if *c > 0 {
+            *c -= 1;
+            inter += 1;
+        }
+    }
+    2.0 * inter as f64 / (ba.len() + bb.len()) as f64
+}
+
 /// Render correspondences as deterministic, human-readable lines.
 pub fn render(cs: &[Correspondence]) -> String {
     let mut s = String::new();
@@ -111,6 +205,13 @@ pub fn render(cs: &[Correspondence]) -> String {
             Correspondence::Renamed { from, to } => {
                 s.push_str(&format!("renamed    {from} -> {to}\n"))
             }
+            Correspondence::RenamedEdited {
+                from,
+                to,
+                similarity,
+            } => s.push_str(&format!(
+                "renamed+   {from} -> {to} ({similarity}% similar)\n"
+            )),
             Correspondence::Modified { name } => s.push_str(&format!("modified   {name}\n")),
             Correspondence::Added { name } => s.push_str(&format!("added      {name}\n")),
             Correspondence::Removed { name } => s.push_str(&format!("removed    {name}\n")),
@@ -171,7 +272,11 @@ mod tests {
 
     #[test]
     fn added_and_removed() {
-        let cs = matched("fn gone() -> i32 { 1 }", "fn fresh() -> i32 { 9 }");
+        // Genuinely dissimilar bodies → below the fuzzy threshold → add/remove.
+        let cs = matched(
+            "fn gone() -> i32 { 1 }",
+            "fn fresh(a: i32, b: i32) -> i32 { a * b - a + b + 42 }",
+        );
         assert_eq!(
             cs,
             vec![
@@ -186,10 +291,53 @@ mod tests {
     }
 
     #[test]
+    fn renamed_and_edited_is_a_fuzzy_match() {
+        // Different name AND a small body edit → recognized as the same node.
+        let cs = matched(
+            "fn parseConfig(s: i32) -> i32 { let x = s + 1; x * 2 }",
+            "fn loadSettings(s: i32) -> i32 { let x = s + 1; x * 3 }",
+        );
+        match cs.as_slice() {
+            [Correspondence::RenamedEdited {
+                from,
+                to,
+                similarity,
+            }] => {
+                assert_eq!(
+                    (from.as_str(), to.as_str()),
+                    ("parseConfig", "loadSettings")
+                );
+                assert!(*similarity >= 80, "similarity was {similarity}");
+            }
+            other => panic!("expected one RenamedEdited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dissimilar_bodies_do_not_fuzzy_match() {
+        // Different name and an unrelated body → add/remove, not a fuzzy match.
+        let cs = matched(
+            "fn alpha() -> i32 { 1 + 2 + 3 }",
+            "fn omega(a: i32, b: i32) -> i32 { let p = a + b; let q = a - b; helper(p, q) }",
+        );
+        assert_eq!(
+            cs,
+            vec![
+                Correspondence::Removed {
+                    name: "alpha".into()
+                },
+                Correspondence::Added {
+                    name: "omega".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn mixed_change_set() {
         let cs = matched(
             "fn keep()->i32{1}\nfn edit()->i32{2}\nfn old()->i32{3}\nfn drop()->i32{4}",
-            "fn keep()->i32{1}\nfn edit()->i32{9}\nfn renamed()->i32{3}\nfn brand()->i32{5}",
+            "fn keep()->i32{1}\nfn edit()->i32{9}\nfn renamed()->i32{3}\nfn brand(a:i32,b:i32)->i32{a*b+a-b}",
         );
         assert_eq!(
             cs,
@@ -229,22 +377,20 @@ mod tests {
     }
 
     #[test]
-    fn recursive_rename_reads_as_modified_or_removed() {
-        // Documented limitation: a recursive body references the old name, so
-        // blanking only the declaration does not make the shapes match. The fn
-        // is not recognized as a rename.
+    fn recursive_rename_is_recovered_by_fuzzy() {
+        // A recursive body references the old name, so the *exact* shape hashes
+        // differ (the body changed too). The fuzzy pass recovers it: the bodies
+        // are still highly similar, so it reads as renamed-and-edited — not a
+        // spurious remove/add.
         let cs = matched(
             "fn fac(n: i32) -> i32 { fac(n) }",
             "fn factorial(n: i32) -> i32 { factorial(n) }",
         );
-        assert_eq!(
-            cs,
-            vec![
-                Correspondence::Removed { name: "fac".into() },
-                Correspondence::Added {
-                    name: "factorial".into()
-                },
-            ]
-        );
+        match cs.as_slice() {
+            [Correspondence::RenamedEdited { from, to, .. }] => {
+                assert_eq!((from.as_str(), to.as_str()), ("fac", "factorial"));
+            }
+            other => panic!("expected RenamedEdited, got {other:?}"),
+        }
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -97,6 +97,10 @@ pub struct Def {
     /// declaration; a recursive body still references the old name, so a recursive
     /// rename reads as a body edit, not a rename.)
     pub shape_hash: String,
+    /// The name-blanked canonical text `shape_hash` is computed from. Kept so the
+    /// fuzzy matcher in [`crate::identity`] can *measure* body similarity (not
+    /// just test equality) — recognizing a function that was renamed *and* edited.
+    pub shape_source: String,
 }
 
 /// The first **verbspec read verb** — "look at the AST."
@@ -137,6 +141,7 @@ pub fn inspect(source: &[u8]) -> Result<Vec<Def>, Error> {
             name,
             content_hash: fnv1a_hex(canonical.as_bytes()),
             shape_hash: fnv1a_hex(shaped.as_bytes()),
+            shape_source: shaped,
         });
     }
     Ok(defs)

--- a/tests/identity_cli.rs
+++ b/tests/identity_cli.rs
@@ -28,9 +28,17 @@ fn run_match(old: &str, new: &str) -> String {
 }
 
 #[test]
-fn match_verb_tracks_rename_modify_add_remove() {
-    let old = "fn keep()->i32{1}\nfn edit()->i32{2}\nfn renameMe()->i32{3}\nfn drop()->i32{4}";
-    let new = "fn keep()->i32{1}\nfn edit()->i32{99}\nfn renamed()->i32{3}\nfn fresh()->i32{5}";
+fn match_verb_tracks_all_correspondences() {
+    let old = "fn keep()->i32{1}\n\
+               fn edit()->i32{2}\n\
+               fn renameMe(x: i32)->i32{x+1}\n\
+               fn parseConfig(s: i32)->i32{let v = s + 1; v * 2}\n\
+               fn gone()->i32{4}";
+    let new = "fn keep()->i32{1}\n\
+               fn edit()->i32{99}\n\
+               fn renamed(x: i32)->i32{x+1}\n\
+               fn loadSettings(s: i32)->i32{let v = s + 1; v * 3}\n\
+               fn fresh(a: i32, b: i32)->i32{let p = a + b; helper(p)}";
     let out = run_match(old, new);
     assert!(out.contains("unchanged  keep"), "got:\n{out}");
     assert!(out.contains("modified   edit"), "got:\n{out}");
@@ -38,6 +46,11 @@ fn match_verb_tracks_rename_modify_add_remove() {
         out.contains("renamed    renameMe -> renamed"),
         "got:\n{out}"
     );
-    assert!(out.contains("removed    drop"), "got:\n{out}");
+    // Fuzzy: renamed AND edited.
+    assert!(
+        out.contains("renamed+   parseConfig -> loadSettings"),
+        "got:\n{out}"
+    );
+    assert!(out.contains("removed    gone"), "got:\n{out}");
     assert!(out.contains("added      fresh"), "got:\n{out}");
 }


### PR DESCRIPTION
## Summary

Extends node identity (**8.1d**) past the exact matches. A function whose **name *and* body both changed** — so neither `content_hash` nor `shape_hash` matches — is now recovered by a **fuzzy** pass instead of showing as a spurious remove+add:

```
renamed+   parseConfig -> loadSettings (96% similar)
```

- **`src/printer.rs`** — `Def` gains `shape_source` (the name-blanked canonical text), so the matcher can *measure* body similarity, not just test hash equality.
- **`src/identity.rs`** — new `Correspondence::RenamedEdited { from, to, similarity }`; `match_defs` pass 4 ranks leftover pairs by **Sørensen–Dice** similarity over the *bodies* (signature stripped — short functions aren't matched on shared `fn _(…) -> … {` boilerplate) and assigns greedily above a 0.5 threshold.
- The **recursive-rename** case that exact shape-matching misses (the body references the old name) is now recovered by fuzzy.

## Tests — all green (68 unit + 15 cucumber/87 steps + identity e2e + 5 merge)
- fuzzy unit tests: renamed-and-edited matches; **dissimilar bodies stay add/remove**; recursive rename recovered
- CLI e2e now covers all six correspondences incl. `renamed+`

## Honest limit
This is **string similarity over the canonical body** — the lightweight cousin of a real GumTree *tree-edit script*, and noisier for very small functions (less body to compare; documented). **Structural** fuzzy matching + the deeper identity axes (binding/use-site, deep content, non-`fn` items, cross-file, git-notes persistence) remain 8.1d's frontier.

## Trust ledger
Strengthens **8.1d** (still 🟡): node identity now handles rename-and-edit, not just exact matches. Full ✅ awaits structural fuzzy matching + the deeper axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)