### PR TITLE
feat: structural node matching via Merkle subtree hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ The core pipeline is implemented and runs through real Git:
   two versions. Exact, content-addressed matches first — a function tracked
   through a **rename** (`renamed parse -> deserialize`), a **reorder**
   (`unchanged`), or a **body edit** (`modified`), plus `added`/`removed`. Then a
-  **fuzzy** pass catches the hard case — a function **renamed *and* edited at
-  once** (`renamed+ parseConfig -> loadSettings (96% similar)`) — by Sørensen–Dice
-  similarity over the bodies. Full structural (GumTree-style) matching is the
-  remaining frontier (below).
+  **structural fuzzy** pass catches the hard case — a function **renamed *and*
+  edited at once** (`renamed+ parseConfig -> loadSettings`) — by Sørensen–Dice
+  similarity over **Merkle subtree hashes** (GumTree's bottom-up phase: shared
+  subtrees match for free, formatting- and statement-order-invariant). A full
+  edit *script* (move detection) is the remaining frontier (below).
 - **Structural 3-way merge for JSON.** `git-ast setup` wires a real merge driver
   ([`src/merge.rs`](./src/merge.rs)): on `git merge`, JSON is merged by
   **structure** — edits and additions to *different* object keys merge cleanly
@@ -108,18 +109,17 @@ Honest boundaries:
   element-level diffing/merging are later increments. The merge is both
   property-tested in Rust and **Lean-proven** ([`proofs/`](./proofs/README.md));
   the diff is Rust-tested.
-- **Node identity: matching works (exact + lightweight fuzzy); structural fuzzy
-  and the deeper axes remain.** `git-ast match` recognizes a function across a
-  rename, reorder, or body edit (exact, content-addressed) *and* across a
-  simultaneous rename-and-edit (fuzzy, via body string-similarity). What it does
-  **not** yet do: **structural** fuzzy matching (a real GumTree tree-edit script,
-  rather than string similarity over the canonical body), the deeper identity axes
-  (deep/Merkle content, binding identity via name resolution, use-site identity),
-  non-`fn` items, cross-file matching, and persisting attribution (git notes).
-  Those — refactor-aware blame in full — remain the open research problem described
-  in [`docs/planning/scope.md`](./docs/planning/scope.md). Note the fuzzy match is a
-  heuristic with a similarity threshold; very small functions are noisier (less
-  body to compare).
+- **Node identity: matching is structural; the edit script and deeper axes
+  remain.** `git-ast match` recognizes a function across a rename, reorder, or body
+  edit (exact, content-addressed) *and* across a simultaneous rename-and-edit
+  (**structural** fuzzy — Sørensen–Dice over Merkle subtree hashes, GumTree's
+  bottom-up phase; per-node deep/Merkle content now exists). What it does **not**
+  yet do: a full GumTree **edit script** (the top-down phase, with *move*
+  detection), the remaining identity axes (binding identity via name resolution,
+  use-site identity), non-`fn` items, cross-file matching, and persisting
+  attribution (git notes). Those — refactor-aware blame in full — remain the open
+  research problem in [`docs/planning/scope.md`](./docs/planning/scope.md). (The
+  fuzzy match is still a similarity heuristic with a threshold.)
 
 ## On stable node identity (the hard part)
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -11,13 +11,14 @@
 //! - **shape_hash** (body, declared name blanked) equal → a **rename** (same body,
 //!   new name).
 //!
-//! [`match_defs`] layers these strongest-first, then adds a **fuzzy** final pass:
-//! leftover defs (a different name *and* a different body) are scored by
-//! Sørensen–Dice similarity over their name-blanked bodies and paired greedily
-//! above a threshold — recognizing a function that was **renamed and edited at
-//! once**. This is the lightweight cousin of GumTree-family matching (string
-//! similarity, not a tree edit script); full structural fuzzy matching remains
-//! the deeper frontier.
+//! [`match_defs`] layers these strongest-first, then adds a **structural fuzzy**
+//! final pass: leftover defs (a different name *and* a different body) are scored
+//! by Sørensen–Dice similarity over their **Merkle subtree-hash multisets**
+//! ([`crate::printer::Def::subtree_hashes`]) and paired greedily above a threshold
+//! — recognizing a function that was **renamed and edited at once**. Comparing
+//! shared *subtrees* (not body text) is GumTree's bottom-up phase: it is
+//! formatting- and statement-order-invariant. A full edit *script* (the top-down
+//! phase, with move detection) remains the deeper frontier.
 
 use crate::printer::Def;
 
@@ -103,12 +104,9 @@ pub fn match_defs(old: &[Def], new: &[Def]) -> Vec<Correspondence> {
     let mut ranked: Vec<(f64, usize, usize)> = Vec::new();
     for &oi in &leftover(&old_used) {
         for &ni in &leftover(&new_used) {
-            // Compare *bodies* (post-signature), so short functions are not
-            // matched on shared `fn _(…) -> … {` boilerplate.
-            let s = dice(
-                body_of(&old[oi].shape_source),
-                body_of(&new[ni].shape_source),
-            );
+            // Structural similarity: shared Merkle subtrees (GumTree bottom-up),
+            // not string overlap — formatting- and order-invariant.
+            let s = structural_dice(&old[oi].subtree_hashes, &new[ni].subtree_hashes);
             if s >= SIMILARITY_THRESHOLD {
                 ranked.push((s, oi, ni));
             }
@@ -161,39 +159,27 @@ pub fn match_defs(old: &[Def], new: &[Def]) -> Vec<Correspondence> {
 /// as the same node renamed-and-edited; below it, they are add/remove.
 const SIMILARITY_THRESHOLD: f64 = 0.5;
 
-/// The function body: from the first `{` onward (signature stripped). Falls back
-/// to the whole string if there is no brace.
-fn body_of(shape: &str) -> &str {
-    match shape.find('{') {
-        Some(i) => &shape[i..],
-        None => shape,
+/// Sørensen–Dice coefficient over the two **Merkle subtree-hash multisets**:
+/// `2·|A∩B| / (|A|+|B|)`. A structural similarity in `[0, 1]` — shared subtrees
+/// (formatting- and order-invariant) count exactly. The inputs are sorted, but we
+/// count via a map so the measure is a true multiset intersection.
+fn structural_dice(a: &[u64], b: &[u64]) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return if a.len() == b.len() { 1.0 } else { 0.0 };
     }
-}
-
-/// Sørensen–Dice coefficient over character bigrams: `2·|A∩B| / (|A|+|B|)`,
-/// a dependency-free string similarity in `[0, 1]`.
-fn dice(a: &str, b: &str) -> f64 {
-    let bigrams = |s: &str| -> Vec<(char, char)> {
-        let chars: Vec<char> = s.chars().collect();
-        chars.windows(2).map(|w| (w[0], w[1])).collect()
-    };
-    let (ba, bb) = (bigrams(a), bigrams(b));
-    if ba.is_empty() || bb.is_empty() {
-        return if ba.len() == bb.len() { 1.0 } else { 0.0 };
-    }
-    let mut counts: std::collections::HashMap<(char, char), i32> = std::collections::HashMap::new();
-    for g in &ba {
-        *counts.entry(*g).or_insert(0) += 1;
+    let mut counts: std::collections::HashMap<u64, i32> = std::collections::HashMap::new();
+    for &h in a {
+        *counts.entry(h).or_insert(0) += 1;
     }
     let mut inter = 0usize;
-    for g in &bb {
-        let c = counts.entry(*g).or_insert(0);
+    for &h in b {
+        let c = counts.entry(h).or_insert(0);
         if *c > 0 {
             *c -= 1;
             inter += 1;
         }
     }
-    2.0 * inter as f64 / (ba.len() + bb.len()) as f64
+    2.0 * inter as f64 / (a.len() + b.len()) as f64
 }
 
 /// Render correspondences as deterministic, human-readable lines.
@@ -307,9 +293,28 @@ mod tests {
                     (from.as_str(), to.as_str()),
                     ("parseConfig", "loadSettings")
                 );
-                assert!(*similarity >= 80, "similarity was {similarity}");
+                // Structural Dice: shared subtrees, minus the edited node's
+                // ancestor chain. Above the match threshold, below string Dice.
+                assert!(*similarity >= 50, "similarity was {similarity}");
             }
             other => panic!("expected one RenamedEdited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reordered_and_edited_matches_structurally() {
+        // Statements reordered AND one edited, plus renamed. The Merkle subtree
+        // multiset is order-independent, so the moved `let` statements still match
+        // — recognized as the same node where string similarity would be shakier.
+        let cs = matched(
+            "fn f(a: i32, b: i32) -> i32 { let x = a + 1; let y = b + 2; x * y }",
+            "fn g(a: i32, b: i32) -> i32 { let y = b + 2; let x = a + 1; x + y }",
+        );
+        match cs.as_slice() {
+            [Correspondence::RenamedEdited { from, to, .. }] => {
+                assert_eq!((from.as_str(), to.as_str()), ("f", "g"));
+            }
+            other => panic!("expected RenamedEdited f -> g, got {other:?}"),
         }
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -97,10 +97,11 @@ pub struct Def {
     /// declaration; a recursive body still references the old name, so a recursive
     /// rename reads as a body edit, not a rename.)
     pub shape_hash: String,
-    /// The name-blanked canonical text `shape_hash` is computed from. Kept so the
-    /// fuzzy matcher in [`crate::identity`] can *measure* body similarity (not
-    /// just test equality) — recognizing a function that was renamed *and* edited.
-    pub shape_source: String,
+    /// The multiset of Merkle subtree hashes (sorted) of the function's CST — the
+    /// node's deep content. The fuzzy matcher in [`crate::identity`] measures
+    /// *structural* similarity over these (shared subtrees), recognizing a
+    /// function that was renamed *and* edited at once.
+    pub subtree_hashes: Vec<u64>,
 }
 
 /// The first **verbspec read verb** — "look at the AST."
@@ -141,22 +142,57 @@ pub fn inspect(source: &[u8]) -> Result<Vec<Def>, Error> {
             name,
             content_hash: fnv1a_hex(canonical.as_bytes()),
             shape_hash: fnv1a_hex(shaped.as_bytes()),
-            shape_source: shaped,
+            subtree_hashes: subtree_hashes(item, source),
         });
     }
     Ok(defs)
 }
 
-/// Dependency-free, deterministic 64-bit FNV-1a hash, rendered as hex. Adequate
-/// for a content-identity proof-of-concept; a real model store would use a
-/// cryptographic hash.
-fn fnv1a_hex(bytes: &[u8]) -> String {
+/// Dependency-free, deterministic 64-bit FNV-1a hash. Adequate for content
+/// identity here; a real model store would use a cryptographic hash.
+fn fnv1a(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for &byte in bytes {
         hash ^= byte as u64;
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    format!("{hash:016x}")
+    hash
+}
+
+/// [`fnv1a`] rendered as fixed-width hex.
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    format!("{:016x}", fnv1a(bytes))
+}
+
+/// The multiset of **Merkle subtree hashes** of `node` (post-order). Each node is
+/// hashed as `fnv1a(kind ++ (leaf ? text : child_hashes))`, so a subtree's hash is
+/// the deep content of that subtree — text-inclusive and formatting-invariant.
+/// Two functions that share a sub-expression share its hash exactly; this is the
+/// bottom-up phase of structural (GumTree-family) matching. Returned sorted.
+pub fn subtree_hashes(node: Node, src: &[u8]) -> Vec<u64> {
+    let mut out = Vec::new();
+    hash_subtree(node, src, &mut out);
+    out.sort_unstable();
+    out
+}
+
+fn hash_subtree(node: Node, src: &[u8], out: &mut Vec<u64>) -> u64 {
+    let mut buf = node.kind().as_bytes().to_vec();
+    buf.push(0);
+    if node.named_child_count() == 0 {
+        if let Ok(text) = node.utf8_text(src) {
+            buf.extend_from_slice(text.as_bytes());
+        }
+    } else {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            let ch = hash_subtree(child, src, out);
+            buf.extend_from_slice(&ch.to_le_bytes());
+        }
+    }
+    let h = fnv1a(&buf);
+    out.push(h);
+    h
 }
 
 struct Printer<'a> {
@@ -790,6 +826,25 @@ mod tests {
         let defs = inspect(b"fn a()->i32{1+2}\nfn b()->i32{1-2}").unwrap();
         assert_eq!(defs.iter().map(|d| &d.name).collect::<Vec<_>>(), ["a", "b"]);
         assert_ne!(defs[0].content_hash, defs[1].content_hash);
+    }
+
+    #[test]
+    fn subtree_hashes_are_formatting_invariant_and_share_subexpressions() {
+        // Same function, two formattings → identical subtree-hash multisets.
+        let a = &inspect(b"fn f(x:i32)->i32{x+1}").unwrap()[0];
+        let b = &inspect(b"fn f(x: i32) -> i32 {\n\n    x + 1\n}\n").unwrap()[0];
+        assert_eq!(a.subtree_hashes, b.subtree_hashes);
+        // Two functions sharing the sub-expression `x + 1` share its subtree hash.
+        let c = &inspect(b"fn g(x: i32) -> i32 { x + 1 + 2 }").unwrap()[0];
+        let common = a
+            .subtree_hashes
+            .iter()
+            .filter(|h| c.subtree_hashes.contains(h))
+            .count();
+        assert!(
+            common > 0,
+            "shared sub-expression should share a subtree hash"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the string-similarity fuzzy measure with a **structural** one — GumTree's bottom-up phase. Each function is reduced to the **multiset of its Merkle subtree hashes**; the fuzzy pass scores leftover defs by Sørensen–Dice over those multisets. Shared subtrees match for free — **formatting- *and* statement-order-invariant**.

- **`src/printer.rs`** — `subtree_hashes(node, src)` post-order-walks a function's CST, hashing each node as `fnv1a(kind ++ (leaf ? text : child_hashes))` — the node's **deep/Merkle content**. `Def` gains `subtree_hashes: Vec<u64>`, drops the string `shape_source`.
- **`src/identity.rs`** — `structural_dice(&[u64], &[u64])` (multiset Dice) replaces the string measure in the fuzzy pass.

## Why it's better than string similarity
A function whose **statements are reordered *and* one is edited** is still recognized as the same node (the subtree multiset is order-independent), where string overlap is shakier. New test `reordered_and_edited_matches_structurally` covers exactly this. It also delivers the **deep/Merkle-content** identity axis.

## Tests — all green (70 unit + 15 cucumber/87 steps + identity e2e + 5 merge)
- `subtree_hashes` property test (formatting-invariant; a shared sub-expression shares a hash)
- structural fuzzy: renamed-and-edited matches, reordered-and-edited matches, dissimilar stays add/remove, recursive rename recovered
- similarity %s are lower than string Dice (Merkle edits propagate up the ancestor chain), so the threshold/assertions are tuned accordingly

## Out of scope (GumTree top-down phase)
A full **edit script** with *move* detection, plus binding/use-site identity, non-`fn` items, cross-file matching, git-notes persistence.

## Trust ledger
Strengthens **8.1d** (stays 🟡): node matching is now *structural* (subtree Merkle hashing), not string-based, and per-node deep content exists. Full ✅ awaits the edit script + the deeper axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)