### PR TITLE
feat: statement-level structural edit script (GumTree top-down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ The core pipeline is implemented and runs through real Git:
   **structural fuzzy** pass catches the hard case — a function **renamed *and*
   edited at once** (`renamed+ parseConfig -> loadSettings`) — by Sørensen–Dice
   similarity over **Merkle subtree hashes** (GumTree's bottom-up phase: shared
-  subtrees match for free, formatting- and statement-order-invariant). A full
-  edit *script* (move detection) is the remaining frontier (below).
+  subtrees match for free, formatting- and statement-order-invariant). And
+  `git-ast match --script` prints a statement-level **edit script** inside each
+  changed function — `moved` / `changed a * 2 -> a * 3` / `inserted` / `deleted`,
+  with move detection (the GumTree top-down phase at statement granularity).
+  Sub-statement granularity is the remaining frontier (below).
 - **Structural 3-way merge for JSON.** `git-ast setup` wires a real merge driver
   ([`src/merge.rs`](./src/merge.rs)): on `git merge`, JSON is merged by
   **structure** — edits and additions to *different* object keys merge cleanly
@@ -109,16 +112,18 @@ Honest boundaries:
   element-level diffing/merging are later increments. The merge is both
   property-tested in Rust and **Lean-proven** ([`proofs/`](./proofs/README.md));
   the diff is Rust-tested.
-- **Node identity: matching is structural; the edit script and deeper axes
-  remain.** `git-ast match` recognizes a function across a rename, reorder, or body
-  edit (exact, content-addressed) *and* across a simultaneous rename-and-edit
-  (**structural** fuzzy — Sørensen–Dice over Merkle subtree hashes, GumTree's
-  bottom-up phase; per-node deep/Merkle content now exists). What it does **not**
-  yet do: a full GumTree **edit script** (the top-down phase, with *move*
-  detection), the remaining identity axes (binding identity via name resolution,
-  use-site identity), non-`fn` items, cross-file matching, and persisting
-  attribution (git notes). Those — refactor-aware blame in full — remain the open
-  research problem in [`docs/planning/scope.md`](./docs/planning/scope.md). (The
+- **Node identity: matching is structural, with a statement-level edit script;
+  sub-statement granularity and the deeper axes remain.** `git-ast match`
+  recognizes a function across a rename, reorder, or body edit (exact,
+  content-addressed) *and* a simultaneous rename-and-edit (**structural** fuzzy —
+  Merkle subtree hashes, GumTree bottom-up); `--script` reports per-statement
+  `moved`/`changed`/`inserted`/`deleted` with move detection (GumTree top-down, at
+  statement granularity). What it does **not** yet do: **sub-statement** edit
+  scripts (recurse into a changed statement's expression tree), the remaining
+  identity axes (binding identity via name resolution, use-site identity), non-`fn`
+  items, cross-file matching, and persisting attribution (git notes). Those —
+  refactor-aware blame in full — remain the open research problem in
+  [`docs/planning/scope.md`](./docs/planning/scope.md). (The
   fuzzy match is still a similarity heuristic with a threshold.)
 
 ## On stable node identity (the hard part)

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -20,7 +20,7 @@
 //! formatting- and statement-order-invariant. A full edit *script* (the top-down
 //! phase, with move detection) remains the deeper frontier.
 
-use crate::printer::Def;
+use crate::printer::{Def, Statement};
 
 /// How a definition corresponds across two versions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -184,26 +184,176 @@ fn structural_dice(a: &[u64], b: &[u64]) -> f64 {
 
 /// Render correspondences as deterministic, human-readable lines.
 pub fn render(cs: &[Correspondence]) -> String {
-    let mut s = String::new();
-    for c in cs {
-        match c {
-            Correspondence::Unchanged { name } => s.push_str(&format!("unchanged  {name}\n")),
-            Correspondence::Renamed { from, to } => {
-                s.push_str(&format!("renamed    {from} -> {to}\n"))
-            }
-            Correspondence::RenamedEdited {
-                from,
-                to,
-                similarity,
-            } => s.push_str(&format!(
-                "renamed+   {from} -> {to} ({similarity}% similar)\n"
-            )),
-            Correspondence::Modified { name } => s.push_str(&format!("modified   {name}\n")),
-            Correspondence::Added { name } => s.push_str(&format!("added      {name}\n")),
-            Correspondence::Removed { name } => s.push_str(&format!("removed    {name}\n")),
+    cs.iter().map(render_correspondence).collect()
+}
+
+/// Render one correspondence as a single line (terminated by `\n`).
+pub fn render_correspondence(c: &Correspondence) -> String {
+    match c {
+        Correspondence::Unchanged { name } => format!("unchanged  {name}\n"),
+        Correspondence::Renamed { from, to } => format!("renamed    {from} -> {to}\n"),
+        Correspondence::RenamedEdited {
+            from,
+            to,
+            similarity,
+        } => format!("renamed+   {from} -> {to} ({similarity}% similar)\n"),
+        Correspondence::Modified { name } => format!("modified   {name}\n"),
+        Correspondence::Added { name } => format!("added      {name}\n"),
+        Correspondence::Removed { name } => format!("removed    {name}\n"),
+    }
+}
+
+/// A statement-level structural change inside a matched function — the unit of the
+/// GumTree top-down edit script (see [`edit_script`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditOp {
+    /// Same statement, different position (matched by hash, out of order).
+    Moved { text: String },
+    /// A statement edited in place (matched by sub-structure similarity).
+    Changed { from: String, to: String },
+    /// A statement present only in the new version.
+    Inserted { text: String },
+    /// A statement present only in the old version.
+    Deleted { text: String },
+}
+
+/// Statement-level structural edit script between two function bodies. The
+/// unchanged in-order backbone (the LCS over statement hashes) is the context and
+/// is not emitted; only moves, in-place changes, insertions and deletions are.
+pub fn edit_script(old: &[Statement], new: &[Statement]) -> Vec<EditOp> {
+    let old_h: Vec<u64> = old.iter().map(|s| s.hash).collect();
+    let new_h: Vec<u64> = new.iter().map(|s| s.hash).collect();
+    let mut old_used = vec![false; old.len()];
+    let mut new_used = vec![false; new.len()];
+
+    // 1. Unchanged backbone: LCS over statement hashes (in-order exact matches).
+    for (oi, ni) in lcs_pairs(&old_h, &new_h) {
+        old_used[oi] = true;
+        new_used[ni] = true;
+    }
+
+    // Collect with a key for deterministic ordering (new position; old for deletes).
+    let mut keyed: Vec<(usize, EditOp)> = Vec::new();
+    let mut deletes: Vec<(usize, EditOp)> = Vec::new();
+
+    // 2. Exact match, out of order → Moved.
+    for oi in 0..old.len() {
+        if old_used[oi] {
+            continue;
+        }
+        if let Some(ni) = (0..new.len()).find(|&ni| !new_used[ni] && new_h[ni] == old_h[oi]) {
+            old_used[oi] = true;
+            new_used[ni] = true;
+            keyed.push((
+                ni,
+                EditOp::Moved {
+                    text: new[ni].text.clone(),
+                },
+            ));
         }
     }
-    s
+
+    // 3. In-place edit → Changed (best sub-structure similarity above the threshold).
+    let mut ranked: Vec<(f64, usize, usize)> = Vec::new();
+    for oi in 0..old.len() {
+        if old_used[oi] {
+            continue;
+        }
+        for ni in 0..new.len() {
+            if new_used[ni] {
+                continue;
+            }
+            let s = structural_dice(&old[oi].subtrees, &new[ni].subtrees);
+            if s >= SIMILARITY_THRESHOLD {
+                ranked.push((s, oi, ni));
+            }
+        }
+    }
+    ranked.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap()
+            .then(a.1.cmp(&b.1))
+            .then(a.2.cmp(&b.2))
+    });
+    for (_s, oi, ni) in ranked {
+        if old_used[oi] || new_used[ni] {
+            continue;
+        }
+        old_used[oi] = true;
+        new_used[ni] = true;
+        keyed.push((
+            ni,
+            EditOp::Changed {
+                from: old[oi].text.clone(),
+                to: new[ni].text.clone(),
+            },
+        ));
+    }
+
+    // 4. Leftovers: insertions (new) and deletions (old).
+    for ni in 0..new.len() {
+        if !new_used[ni] {
+            keyed.push((
+                ni,
+                EditOp::Inserted {
+                    text: new[ni].text.clone(),
+                },
+            ));
+        }
+    }
+    for oi in 0..old.len() {
+        if !old_used[oi] {
+            deletes.push((
+                oi,
+                EditOp::Deleted {
+                    text: old[oi].text.clone(),
+                },
+            ));
+        }
+    }
+
+    keyed.sort_by_key(|(k, _)| *k);
+    deletes.sort_by_key(|(k, _)| *k);
+    keyed.into_iter().chain(deletes).map(|(_, op)| op).collect()
+}
+
+/// Longest common subsequence (index pairs) of two hash sequences.
+fn lcs_pairs(a: &[u64], b: &[u64]) -> Vec<(usize, usize)> {
+    let (n, m) = (a.len(), b.len());
+    let mut dp = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i][j] = if a[i] == b[j] {
+                dp[i + 1][j + 1] + 1
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+    let mut pairs = Vec::new();
+    let (mut i, mut j) = (0, 0);
+    while i < n && j < m {
+        if a[i] == b[j] {
+            pairs.push((i, j));
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    pairs
+}
+
+/// Render one edit-script operation, indented under its function line.
+pub fn render_edit_op(op: &EditOp) -> String {
+    match op {
+        EditOp::Moved { text } => format!("    moved      {text}\n"),
+        EditOp::Changed { from, to } => format!("    changed    {from}  ->  {to}\n"),
+        EditOp::Inserted { text } => format!("    inserted   {text}\n"),
+        EditOp::Deleted { text } => format!("    deleted    {text}\n"),
+    }
 }
 
 #[cfg(test)]
@@ -397,5 +547,66 @@ mod tests {
             }
             other => panic!("expected RenamedEdited, got {other:?}"),
         }
+    }
+
+    // --- Statement-level edit script ---
+
+    fn script(old: &str, new: &str) -> Vec<EditOp> {
+        let o = crate::printer::function_statements(old.as_bytes(), "f").unwrap();
+        let n = crate::printer::function_statements(new.as_bytes(), "f").unwrap();
+        edit_script(&o, &n)
+    }
+
+    #[test]
+    fn edit_script_inserted_and_deleted() {
+        assert_eq!(
+            script(
+                "fn f() -> i32 { let a = 1; a }",
+                "fn f() -> i32 { let a = 1; log(a); a }"
+            ),
+            vec![EditOp::Inserted {
+                text: "log(a);".into()
+            }]
+        );
+        assert_eq!(
+            script(
+                "fn f() -> i32 { let a = 1; log(a); a }",
+                "fn f() -> i32 { let a = 1; a }"
+            ),
+            vec![EditOp::Deleted {
+                text: "log(a);".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn edit_script_changed_in_place() {
+        // Operator captured (subtree hash walks all children), so the binary expr
+        // is recognized as edited, not unchanged.
+        assert_eq!(
+            script(
+                "fn f() -> i32 { let a = 1; a * 2 }",
+                "fn f() -> i32 { let a = 1; a * 3 }"
+            ),
+            vec![EditOp::Changed {
+                from: "a * 2".into(),
+                to: "a * 3".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn edit_script_detects_a_move() {
+        // Two lets reordered; the trailing expr is the unchanged backbone.
+        let ops = script(
+            "fn f() -> i32 { let a = 1; let b = 2; a }",
+            "fn f() -> i32 { let b = 2; let a = 1; a }",
+        );
+        assert!(
+            ops.iter().any(|op| matches!(op, EditOp::Moved { .. })),
+            "expected a Moved op, got {ops:?}"
+        );
+        // No spurious insert/delete: a pure reorder is only moves.
+        assert!(ops.iter().all(|op| matches!(op, EditOp::Moved { .. })));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,18 +65,51 @@ fn run_inspect(args: &[String]) -> Result<u8, Error> {
 }
 
 /// The `match` read verb: correspond top-level definitions across two versions
-/// (`git-ast match <old> <new>`), reporting each as unchanged / renamed /
-/// modified / added / removed via content-addressed identity.
+/// (`git-ast match [--script] <old> <new>`), reporting each as unchanged / renamed
+/// / modified / added / removed via content-addressed identity. With `--script`,
+/// each changed function also gets a statement-level structural edit script.
 fn run_match(args: &[String]) -> Result<u8, Error> {
-    let (Some(old_path), Some(new_path)) = (args.first(), args.get(1)) else {
+    let (script, rest) = match args.split_first() {
+        Some((flag, tail)) if flag == "--script" => (true, tail),
+        _ => (false, args),
+    };
+    let (Some(old_path), Some(new_path)) = (rest.first(), rest.get(1)) else {
         return Err(Error::Config(
-            "match expects two file arguments: git-ast match <old> <new>".to_string(),
+            "match expects: git-ast match [--script] <old> <new>".to_string(),
         ));
     };
-    let old = printer::inspect(&std::fs::read(old_path)?)?;
-    let new = printer::inspect(&std::fs::read(new_path)?)?;
-    print!("{}", identity::render(&identity::match_defs(&old, &new)));
+    let old_src = std::fs::read(old_path)?;
+    let new_src = std::fs::read(new_path)?;
+    let old = printer::inspect(&old_src)?;
+    let new = printer::inspect(&new_src)?;
+
+    for c in identity::match_defs(&old, &new) {
+        print!("{}", identity::render_correspondence(&c));
+        // With --script, show what changed *inside* a matched-but-changed function.
+        if script {
+            if let Some((from, to)) = changed_fn_names(&c) {
+                if let (Some(os), Some(ns)) = (
+                    printer::function_statements(&old_src, from),
+                    printer::function_statements(&new_src, to),
+                ) {
+                    for op in identity::edit_script(&os, &ns) {
+                        print!("{}", identity::render_edit_op(&op));
+                    }
+                }
+            }
+        }
+    }
     Ok(0)
+}
+
+/// The (old, new) function names for a correspondence that changed a body, or
+/// `None` for unchanged/renamed-only/added/removed.
+fn changed_fn_names(c: &identity::Correspondence) -> Option<(&str, &str)> {
+    match c {
+        identity::Correspondence::Modified { name } => Some((name, name)),
+        identity::Correspondence::RenamedEdited { from, to, .. } => Some((from, to)),
+        _ => None,
+    }
 }
 
 fn print_help() {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -179,13 +179,16 @@ pub fn subtree_hashes(node: Node, src: &[u8]) -> Vec<u64> {
 fn hash_subtree(node: Node, src: &[u8], out: &mut Vec<u64>) -> u64 {
     let mut buf = node.kind().as_bytes().to_vec();
     buf.push(0);
-    if node.named_child_count() == 0 {
+    // Walk *all* children (named + anonymous), so operators and keywords (`*` vs
+    // `+`, `let`, …) are part of the hash. Whitespace is not a CST node, so this
+    // stays formatting-invariant.
+    if node.child_count() == 0 {
         if let Ok(text) = node.utf8_text(src) {
             buf.extend_from_slice(text.as_bytes());
         }
     } else {
         let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
+        for child in node.children(&mut cursor) {
             let ch = hash_subtree(child, src, out);
             buf.extend_from_slice(&ch.to_le_bytes());
         }
@@ -193,6 +196,55 @@ fn hash_subtree(node: Node, src: &[u8], out: &mut Vec<u64>) -> u64 {
     let h = fnv1a(&buf);
     out.push(h);
     h
+}
+
+/// The Merkle hash of a single node (its subtree-root hash).
+fn merkle_hash(node: Node, src: &[u8]) -> u64 {
+    let mut scratch = Vec::new();
+    hash_subtree(node, src, &mut scratch)
+}
+
+/// One statement of a function body — the unit of the structural edit script
+/// ([`crate::identity::edit_script`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Statement {
+    /// Merkle hash of the statement subtree (exact identity).
+    pub hash: u64,
+    /// The statement's subtree-hash multiset (for sub-similarity scoring).
+    pub subtrees: Vec<u64>,
+    /// Canonical text of the statement (no indentation, no trailing newline).
+    pub text: String,
+}
+
+/// The ordered statements of the named function's body, each with its Merkle hash,
+/// subtree multiset, and canonical text. Returns `None` if no such function exists
+/// or its body falls outside the supported subset (fail-closed, like [`inspect`]).
+pub fn function_statements(source: &[u8], fn_name: &str) -> Option<Vec<Statement>> {
+    let tree = parse(source).ok()?;
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let func = root.named_children(&mut cursor).find(|n| {
+        n.kind() == "function_item"
+            && n.child_by_field_name("name")
+                .and_then(|x| x.utf8_text(source).ok())
+                == Some(fn_name)
+    })?;
+    let body = func.child_by_field_name("body")?;
+    let mut stmts = Vec::new();
+    let mut bcur = body.walk();
+    for node in body.named_children(&mut bcur) {
+        let mut p = Printer {
+            src: source,
+            out: String::new(),
+        };
+        p.stmt(node, 0).ok()?; // fail-closed on an unsupported construct
+        stmts.push(Statement {
+            hash: merkle_hash(node, source),
+            subtrees: subtree_hashes(node, source),
+            text: p.out.trim_end().to_string(),
+        });
+    }
+    Some(stmts)
 }
 
 struct Printer<'a> {

--- a/tests/identity_cli.rs
+++ b/tests/identity_cli.rs
@@ -54,3 +54,35 @@ fn match_verb_tracks_all_correspondences() {
     assert!(out.contains("removed    gone"), "got:\n{out}");
     assert!(out.contains("added      fresh"), "got:\n{out}");
 }
+
+#[test]
+fn match_script_prints_a_statement_edit_script() {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("match_script");
+    fs::create_dir_all(&dir).unwrap();
+    let old = dir.join("old.rs");
+    let new = dir.join("new.rs");
+    fs::write(
+        &old,
+        "fn compute(a: i32, b: i32) -> i32 { let x = a + 1; let y = b + 2; let tmp = 0; x * y }",
+    )
+    .unwrap();
+    fs::write(
+        &new,
+        "fn compute(a: i32, b: i32) -> i32 { let y = b + 2; let x = a + 1; log(x); x + y }",
+    )
+    .unwrap();
+    let out = Command::new(BIN)
+        .arg("match")
+        .arg("--script")
+        .arg(&old)
+        .arg(&new)
+        .output()
+        .expect("run git-ast match --script");
+    assert!(out.status.success());
+    let out = String::from_utf8(out.stdout).unwrap();
+    assert!(out.contains("modified   compute"), "got:\n{out}");
+    assert!(out.contains("moved      let x = a + 1;"), "got:\n{out}");
+    assert!(out.contains("inserted   log(x);"), "got:\n{out}");
+    assert!(out.contains("changed    x * y  ->  x + y"), "got:\n{out}");
+    assert!(out.contains("deleted    let tmp = 0;"), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

Node identity now reports **what changed inside** a matched function, not just that it changed. `git-ast match --script <old> <new>` prints a per-statement **edit script with move detection** — the GumTree top-down phase at statement granularity:

```
modified   compute
    moved      let x = a + 1;
    inserted   log(x);
    changed    x * y  ->  x + y
    deleted    let tmp = 0;
```

- **`src/printer.rs`** — `function_statements(source, fn_name)` returns the body's ordered statements (Merkle hash + subtree multiset + canonical text). **Bug fix:** `hash_subtree` now walks **all** children, so **operators matter** (`a * 2` ≠ `a * 3`); whitespace still isn't a CST node, so formatting-invariance holds.
- **`src/identity.rs`** — `edit_script` = LCS over statement hashes (unchanged backbone) → `Moved` (exact, out of order) → `Changed` (best sub-structure similarity) → `Inserted`/`Deleted`.
- **`src/main.rs`** — `match --script` interleaves the script under each changed function.

## Tests — all green (73 unit + 15 cucumber/87 steps + 2 identity e2e + 5 merge)
- 3 `edit_script` unit tests (insert/delete, in-place change incl. the operator fix, pure move)
- `match --script` CLI e2e asserting moved/changed/inserted/deleted

## Out of scope (deeper still)
**Sub-statement** (expression-tree) edit scripts, binding/use-site identity, non-`fn` items, cross-file matching, git-notes persistence.

## Trust ledger
Strengthens **8.1d** (stays 🟡): node identity now shows *what* changed inside a matched function (statement-level edit script with move detection). Full ✅ awaits the deeper axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)