### PR TITLE
feat: node identity for all top-level items (not just fns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ The core pipeline is implemented and runs through real Git:
   **formatting-invariant content hash** — a proof-of-concept of the first
   read verb (see "The interface: verbs" below).
 - **Node identity.** `git-ast match <old> <new>`
-  ([`src/identity.rs`](./src/identity.rs)) corresponds top-level functions across
-  two versions. Exact, content-addressed matches first — a function tracked
+  ([`src/identity.rs`](./src/identity.rs)) corresponds top-level items —
+  functions, `struct`s, `enum`s, `const`/`static`, and `impl` blocks — across two
+  versions (matched within their kind). Exact, content-addressed matches first — an
+  item tracked
   through a **rename** (`renamed parse -> deserialize`), a **reorder**
   (`unchanged`), or a **body edit** (`modified`), plus `added`/`removed`. Then a
   **structural fuzzy** pass catches the hard case — a function **renamed *and*
@@ -118,11 +120,12 @@ Honest boundaries:
   content-addressed) *and* a simultaneous rename-and-edit (**structural** fuzzy —
   Merkle subtree hashes, GumTree bottom-up); `--script` reports per-statement
   `moved`/`changed`/`inserted`/`deleted` with move detection (GumTree top-down, at
-  statement granularity). What it does **not** yet do: **sub-statement** edit
-  scripts (recurse into a changed statement's expression tree), the remaining
-  identity axes (binding identity via name resolution, use-site identity), non-`fn`
-  items, cross-file matching, and persisting attribution (git notes). Those —
-  refactor-aware blame in full — remain the open research problem in
+  statement granularity); and it matches all top-level item kinds (`fn`, `struct`,
+  `enum`, `const`/`static`, `impl`), not just functions. What it does **not** yet
+  do: **sub-statement** edit scripts (recurse into a changed statement's expression
+  tree), the remaining identity axes (binding identity via name resolution,
+  use-site identity), cross-file matching, and persisting attribution (git notes).
+  Those — refactor-aware blame in full — remain the open research problem in
   [`docs/planning/scope.md`](./docs/planning/scope.md). (The
   fuzzy match is still a similarity heuristic with a threshold.)
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -70,12 +70,12 @@ pub fn match_defs(old: &[Def], new: &[Def]) -> Vec<Correspondence> {
             });
         }
     }
-    // Pass 2: same name, different body → Modified.
+    // Pass 2: same kind and name, different body → Modified.
     for (oi, o) in old.iter().enumerate() {
         if old_used[oi] {
             continue;
         }
-        if let Some(ni) = first_new(&new_used, &|n| n.name == o.name) {
+        if let Some(ni) = first_new(&new_used, &|n| n.kind == o.kind && n.name == o.name) {
             old_used[oi] = true;
             new_used[ni] = true;
             out.push(Correspondence::Modified {
@@ -608,5 +608,29 @@ mod tests {
         );
         // No spurious insert/delete: a pure reorder is only moves.
         assert!(ops.iter().all(|op| matches!(op, EditOp::Moved { .. })));
+    }
+
+    // --- Non-fn items ---
+
+    #[test]
+    fn matches_structs_enums_and_consts() {
+        let cs = matched(
+            "struct Point { x: i32 }\nenum E { A }\nconst C: i32 = 1;",
+            "struct Coord { x: i32 }\nenum E { A, B }\nconst C: i32 = 2;",
+        );
+        assert!(cs.contains(&Correspondence::Renamed {
+            from: "Point".into(),
+            to: "Coord".into()
+        }));
+        assert!(cs.contains(&Correspondence::Modified { name: "E".into() }));
+        assert!(cs.contains(&Correspondence::Modified { name: "C".into() }));
+    }
+
+    #[test]
+    fn same_name_different_kind_does_not_cross_match() {
+        // A struct and a function that happen to share a name are distinct items.
+        let cs = matched("struct Foo { x: i32 }", "fn Foo() -> i32 { 1 }");
+        assert!(cs.contains(&Correspondence::Removed { name: "Foo".into() }));
+        assert!(cs.contains(&Correspondence::Added { name: "Foo".into() }));
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -82,7 +82,8 @@ fn parse(source: &[u8]) -> Result<tree_sitter::Tree, Error> {
 /// A top-level definition surfaced by the [`inspect`] read verb.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Def {
-    /// Kind of definition (currently always `"fn"`).
+    /// Kind of definition: `"fn"`, `"struct"`, `"enum"`, `"const"`, `"static"`,
+    /// or `"impl"`.
     pub kind: &'static str,
     /// The declared name.
     pub name: String,
@@ -118,30 +119,46 @@ pub fn inspect(source: &[u8]) -> Result<Vec<Def>, Error> {
     let mut defs = Vec::new();
     let mut cursor = root.walk();
     for item in root.named_children(&mut cursor) {
-        if item.kind() != "function_item" {
-            continue;
-        }
+        // The keyword/kind for each supported top-level item (skip comments etc.).
+        let kind: &'static str = match item.kind() {
+            "function_item" => "fn",
+            "struct_item" => "struct",
+            "enum_item" => "enum",
+            "const_item" => "const",
+            "static_item" => "static",
+            "impl_item" => "impl",
+            _ => continue,
+        };
         let mut printer = Printer {
             src: source,
             out: String::new(),
         };
-        if printer.function(item, 0).is_err() {
+        if printer.item(item, 0).is_err() {
             continue; // can't hash what we can't canonicalize
         }
+        // An `impl` has no name of its own; its identity is the type it is for.
+        let name_field = if kind == "impl" { "type" } else { "name" };
         let name = item
-            .child_by_field_name("name")
+            .child_by_field_name(name_field)
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("?")
             .to_string();
-        // Shape hash: blank the declared name (the canonical form always begins
-        // `fn <name>(`), so two bodies that differ only by name share it.
+        // Shape hash: blank the declared name in the canonical form (which begins
+        // `<kw> <name>`), so two items that differ only by name share it — the
+        // seam for rename detection. (`impl` blocks have no leading name to blank,
+        // so their shape hash is just their content hash for now.)
         let canonical = &printer.out;
-        let shaped = canonical.replacen(&format!("fn {name}("), "fn _(", 1);
+        let shape_hash = if kind == "impl" {
+            fnv1a_hex(canonical.as_bytes())
+        } else {
+            let shaped = canonical.replacen(&format!("{kind} {name}"), &format!("{kind} _"), 1);
+            fnv1a_hex(shaped.as_bytes())
+        };
         defs.push(Def {
-            kind: "fn",
+            kind,
             name,
             content_hash: fnv1a_hex(canonical.as_bytes()),
-            shape_hash: fnv1a_hex(shaped.as_bytes()),
+            shape_hash,
             subtree_hashes: subtree_hashes(item, source),
         });
     }
@@ -909,6 +926,29 @@ mod tests {
         // Same name, different body → different shape_hash.
         let c = &inspect(b"fn a(x: i32) -> i32 { x + 2 }").unwrap()[0];
         assert_ne!(a.shape_hash, c.shape_hash, "body must affect shape");
+    }
+
+    #[test]
+    fn inspect_surfaces_all_top_level_item_kinds() {
+        let defs = inspect(
+            b"struct S { x: i32 }\nenum E { A }\nconst C: i32 = 1;\nstatic T: i32 = 2;\nfn f() -> i32 { 1 }\nimpl S { fn m(&self) -> i32 { self.x } }",
+        )
+        .unwrap();
+        let kinds: Vec<(&str, &str)> = defs.iter().map(|d| (d.kind, d.name.as_str())).collect();
+        assert!(kinds.contains(&("struct", "S")));
+        assert!(kinds.contains(&("enum", "E")));
+        assert!(kinds.contains(&("const", "C")));
+        assert!(kinds.contains(&("static", "T")));
+        assert!(kinds.contains(&("fn", "f")));
+        assert!(kinds.contains(&("impl", "S"))); // impl identified by its type
+    }
+
+    #[test]
+    fn struct_rename_with_same_fields_shares_shape_hash() {
+        let a = &inspect(b"struct Point { x: i32, y: i32 }").unwrap()[0];
+        let b = &inspect(b"struct Coord { x: i32, y: i32 }").unwrap()[0];
+        assert_eq!(a.shape_hash, b.shape_hash, "renamed struct, same fields");
+        assert_ne!(a.content_hash, b.content_hash);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extends `git-ast match` beyond functions to **structs, enums, const/static, and impl blocks** — track a *type* through a rename/reorder/edit. The biggest coverage jump: real modules are now fully matchable.

```
renamed   Point -> Coord     # struct renamed, same fields
modified  Color              # enum gained a variant
modified  MAX                # const value changed
unchanged helper             # fn unchanged
```

- **`src/printer.rs`** — `inspect` surfaces `struct_item`/`enum_item`/`const_item`/`static_item`/`impl_item` (via the existing `item` dispatch), each a `Def` with kind + name + content/shape/subtree hashes. `impl` is identified by its **type**; shape-hash name-blanking generalizes from `fn <name>` to `<kw> <name>`, so a renamed struct/enum/const with an unchanged body is a **Rename**.
- **`src/identity.rs`** — the name-match pass now requires the **same kind**, so a struct and a function sharing a name don't cross-match.

## Tests — all green (77 unit + 15 cucumber/87 steps + 2 identity e2e + 5 merge)
- `matches_structs_enums_and_consts`, `same_name_different_kind_does_not_cross_match`, `inspect_surfaces_all_top_level_item_kinds`, `struct_rename_with_same_fields_shares_shape_hash`

## Out of scope
Sub-statement edit scripts; binding/use-site identity; cross-file; git-notes persistence. (The statement-level `--script` stays fn-only; non-`fn` items match at the item level — member-level scripts are a follow-up.)

## Trust ledger
Strengthens **8.1d** (stays 🟡): node identity now covers all top-level item kinds, not just functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)