### PR TITLE
feat: refactor-aware blame (git-ast blame), computed on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This structural approach lets you focus on semantic changes rather than textual 
 
 ## Getting Started
 
+> The binary is named `git-ast`, so once it is on your `PATH` every command also
+> works as a **git subcommand**: `git ast setup`, `git ast match a.rs b.rs`,
+> `git ast blame src/lib.rs`.
+
 - [Installation Guide](./docs/getting-started/installation.md) - Set up Git AST in your environment
 - [Usage Guide](./docs/getting-started/usage.md) - Learn how to use Git AST in your workflow
 - [Documentation](./docs/start-here.md) - Comprehensive documentation
@@ -67,6 +71,13 @@ The core pipeline is implemented and runs through real Git:
 - `git-ast inspect [FILE]` lists top-level definitions with a
   **formatting-invariant content hash** — a proof-of-concept of the first
   read verb (see "The interface: verbs" below).
+- **Refactor-aware blame.** `git-ast blame <file>`
+  ([`src/blame.rs`](./src/blame.rs)) reports, per top-level item, the commit that
+  last changed it — **following it through renames**, so a renamed function blames
+  to where its *body* was written, not the rename commit (what plain `git blame`
+  can't do). It is **computed on demand** by walking the file's history and
+  matching items commit-to-commit — *no `git notes` persistence required*
+  ("identity is computed, not stored").
 - **Node identity.** `git-ast match <old> <new>`
   ([`src/identity.rs`](./src/identity.rs)) corresponds top-level items —
   functions, `struct`s, `enum`s, `const`/`static`, and `impl` blocks — across two
@@ -120,14 +131,16 @@ Honest boundaries:
   content-addressed) *and* a simultaneous rename-and-edit (**structural** fuzzy —
   Merkle subtree hashes, GumTree bottom-up); `--script` reports per-statement
   `moved`/`changed`/`inserted`/`deleted` with move detection (GumTree top-down, at
-  statement granularity); and it matches all top-level item kinds (`fn`, `struct`,
-  `enum`, `const`/`static`, `impl`), not just functions. What it does **not** yet
-  do: **sub-statement** edit scripts (recurse into a changed statement's expression
-  tree), the remaining identity axes (binding identity via name resolution,
-  use-site identity), cross-file matching, and persisting attribution (git notes).
-  Those — refactor-aware blame in full — remain the open research problem in
-  [`docs/planning/scope.md`](./docs/planning/scope.md). (The
-  fuzzy match is still a similarity heuristic with a threshold.)
+  statement granularity); it matches all top-level item kinds (`fn`, `struct`,
+  `enum`, `const`/`static`, `impl`), not just functions; and it powers
+  **refactor-aware blame** (`git-ast blame`, computed on demand). What it does
+  **not** yet do: **per-line** blame (this is per-definition), **sub-statement**
+  edit scripts (recurse into a changed statement's expression tree), the remaining
+  identity axes (binding identity via name resolution, use-site identity),
+  cross-file matching, and *persisting* attribution across history rewrites (the
+  git-notes transport problem). Those — refactor-aware blame in *full* — remain the
+  open research problem in [`docs/planning/scope.md`](./docs/planning/scope.md).
+  (The fuzzy match is still a similarity heuristic with a threshold.)
 
 ## On stable node identity (the hard part)
 

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -1,0 +1,148 @@
+//! Refactor-aware blame, **computed on demand**.
+//!
+//! For each top-level item in a file's committed version, [`blame`] reports the
+//! commit that last changed it — *following it through renames*, so a pure rename
+//! does not reset its history (you see the last real **body** change). This is the
+//! payoff of node identity ([`crate::identity`]): per git-ast's design essay,
+//! *identity is computed, not stored* — so no `git notes` persistence is needed.
+//! We walk the file's history and match items commit-to-commit with [`match_defs`].
+//!
+//! Granularity is **per-definition** (not per-line). Git is shelled in the current
+//! working directory (mirroring [`crate::setup`]).
+
+use crate::identity::{match_defs, Correspondence};
+use crate::printer::{inspect, Def};
+use crate::Error;
+use std::process::Command;
+
+/// The commit that last changed one definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Blame {
+    /// Short commit hash.
+    pub commit: String,
+    /// Kind of the definition (`fn`, `struct`, …).
+    pub kind: &'static str,
+    /// The definition's name in the current version.
+    pub name: String,
+}
+
+/// Blame every top-level item of `file`'s committed version, following each item
+/// through renames to the commit that last changed its body.
+pub fn blame(file: &str) -> Result<Vec<Blame>, Error> {
+    let rel = full_name(file)?;
+    let commits = log_commits(&rel)?; // newest → oldest
+    let Some(head) = commits.first() else {
+        return Err(Error::Driver(format!("{file}: no committed history")));
+    };
+
+    // Definitions at each commit (newest → oldest). The newest commit's version is
+    // the one we blame; older versions tolerate parse failures (treated as absent).
+    let mut defs: Vec<Vec<Def>> = Vec::with_capacity(commits.len());
+    defs.push(inspect(&show(head, &rel)?)?);
+    for c in &commits[1..] {
+        defs.push(inspect(&show(c, &rel)?).unwrap_or_default());
+    }
+
+    let mut out = Vec::new();
+    for head_def in &defs[0] {
+        let mut name = head_def.name.clone();
+        let mut blame = commits[0].clone(); // last commit with the current body
+        let mut i = 0;
+        while i + 1 < commits.len() {
+            match classify(&match_defs(&defs[i + 1], &defs[i]), &name) {
+                Step::Unchanged => {
+                    blame = commits[i + 1].clone();
+                    i += 1;
+                }
+                Step::Renamed(from) => {
+                    name = from;
+                    blame = commits[i + 1].clone();
+                    i += 1;
+                }
+                // Body changed (or first appeared) at the newer commit `i`.
+                Step::Changed | Step::Added => break,
+            }
+        }
+        out.push(Blame {
+            commit: short(&blame),
+            kind: head_def.kind,
+            name: head_def.name.clone(),
+        });
+    }
+    Ok(out)
+}
+
+/// How the tracked item (by its *new* name) corresponds in the older version.
+enum Step {
+    Unchanged,
+    Renamed(String), // the older name (body unchanged)
+    Changed,         // body edited
+    Added,           // not present in the older version
+}
+
+fn classify(corr: &[Correspondence], name: &str) -> Step {
+    for c in corr {
+        match c {
+            Correspondence::Unchanged { name: n } if n == name => return Step::Unchanged,
+            Correspondence::Renamed { from, to } if to == name => {
+                return Step::Renamed(from.clone())
+            }
+            Correspondence::RenamedEdited { to, .. } if to == name => return Step::Changed,
+            Correspondence::Modified { name: n } if n == name => return Step::Changed,
+            Correspondence::Added { name: n } if n == name => return Step::Added,
+            _ => {}
+        }
+    }
+    Step::Added
+}
+
+fn short(commit: &str) -> String {
+    commit.chars().take(7).collect()
+}
+
+/// Run `git <args>` in the current directory, returning stdout text.
+fn git(args: &[&str]) -> Result<String, Error> {
+    let out = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| Error::Driver(format!("running git: {e}")))?;
+    if !out.status.success() {
+        return Err(Error::Driver(format!(
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// The file's repo-root-relative path (errors if the file isn't tracked).
+fn full_name(file: &str) -> Result<String, Error> {
+    git(&["ls-files", "--full-name", "--error-unmatch", "--", file])?
+        .lines()
+        .next()
+        .map(str::to_string)
+        .ok_or_else(|| Error::Driver(format!("{file}: not tracked by git")))
+}
+
+/// Commits that touched `rel`, newest first.
+fn log_commits(rel: &str) -> Result<Vec<String>, Error> {
+    Ok(git(&["log", "--format=%H", "--", rel])?
+        .lines()
+        .map(str::to_string)
+        .collect())
+}
+
+/// Raw bytes of `rel` at `commit`.
+fn show(commit: &str, rel: &str) -> Result<Vec<u8>, Error> {
+    let out = Command::new("git")
+        .args(["show", &format!("{commit}:{rel}")])
+        .output()
+        .map_err(|e| Error::Driver(format!("running git show: {e}")))?;
+    if !out.status.success() {
+        return Err(Error::Driver(format!(
+            "git show {commit}:{rel} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(out.stdout)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //!
 //! Configuration is read via [`config`].
 
+pub mod blame;
 pub mod config;
 pub mod diff;
 pub mod drivers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 use std::io::Read;
 use std::process::ExitCode;
 
-use git_ast::{drivers, filters, identity, printer, setup, Error};
+use git_ast::{blame, drivers, filters, identity, printer, setup, Error};
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -20,6 +20,7 @@ fn main() -> ExitCode {
         "setup" => setup::run().map(|()| 0u8),
         "inspect" => run_inspect(rest),
         "match" => run_match(rest),
+        "blame" => run_blame(rest),
         "filter-process" => filters::run_long_running_filter().map(|()| 0u8),
         "diff-driver" => drivers::run_diff_driver(rest).map(|()| 0u8),
         "merge-driver" => drivers::run_merge_driver(rest).map(|()| 0u8),
@@ -102,6 +103,21 @@ fn run_match(args: &[String]) -> Result<u8, Error> {
     Ok(0)
 }
 
+/// The `blame` verb: refactor-aware, per-definition blame
+/// (`git-ast blame <file>`). For each top-level item, prints the commit that last
+/// changed it — following it through renames.
+fn run_blame(args: &[String]) -> Result<u8, Error> {
+    let Some(file) = args.first() else {
+        return Err(Error::Config(
+            "blame expects a file: git-ast blame <file>".to_string(),
+        ));
+    };
+    for b in blame::blame(file)? {
+        println!("{}  {:<6} {}", b.commit, b.kind, b.name);
+    }
+    Ok(0)
+}
+
 /// The (old, new) function names for a correspondence that changed a body, or
 /// `None` for unchanged/renamed-only/added/removed.
 fn changed_fn_names(c: &identity::Correspondence) -> Option<(&str, &str)> {
@@ -123,6 +139,7 @@ fn print_help() {
          setup             Enable the *.rs and *.json clean/smudge filter here\n    \
          inspect [FILE]    List top-level defs with a formatting-invariant hash\n    \
          match OLD NEW     Correspond defs across two versions (rename/move/edit)\n    \
+         blame FILE        Per-def blame, following items through renames\n    \
          filter-process    Clean/smudge long-running filter (Rust + JSON)\n    \
          diff-driver       Structural diff (JSON); text diff otherwise\n    \
          merge-driver      Structural 3-way merge (JSON)\n    \

--- a/tests/blame_e2e.rs
+++ b/tests/blame_e2e.rs
@@ -1,0 +1,85 @@
+//! End-to-end test of `git-ast blame` against real git history — the refactor-
+//! aware property: a function is followed through a rename.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_git-ast");
+
+fn git(repo: &Path, args: &[&str]) {
+    let ok = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .expect("git")
+        .success();
+    assert!(ok, "git {args:?} failed");
+}
+
+fn commit(repo: &Path, file: &str, content: &str, msg: &str) -> String {
+    fs::write(repo.join(file), content).unwrap();
+    git(repo, &["add", file]);
+    git(repo, &["commit", "-qm", msg]);
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+#[test]
+fn blame_follows_a_function_through_a_rename() {
+    let repo = Path::new(env!("CARGO_TARGET_TMPDIR")).join("blame_repo");
+    let _ = fs::remove_dir_all(&repo);
+    fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-q"]);
+    git(&repo, &["config", "user.email", "t@test.local"]);
+    git(&repo, &["config", "user.name", "t"]);
+
+    // c1: three functions.
+    let c1 = commit(
+        &repo,
+        "m.rs",
+        "fn alpha() -> i32 { 1 }\nfn beta() -> i32 { 2 }\nfn gamma() -> i32 { 3 }\n",
+        "c1",
+    );
+    // c2: edit beta's body.
+    let c2 = commit(
+        &repo,
+        "m.rs",
+        "fn alpha() -> i32 { 1 }\nfn beta() -> i32 { 99 }\nfn gamma() -> i32 { 3 }\n",
+        "c2",
+    );
+    // c3: rename gamma -> gamma2 (body unchanged), and add delta.
+    let c3 = commit(
+        &repo,
+        "m.rs",
+        "fn alpha() -> i32 { 1 }\nfn beta() -> i32 { 99 }\nfn gamma2() -> i32 { 3 }\nfn delta() -> i32 { 4 }\n",
+        "c3",
+    );
+
+    let out = Command::new(BIN)
+        .arg("blame")
+        .arg("m.rs")
+        .current_dir(&repo)
+        .output()
+        .expect("git-ast blame");
+    assert!(
+        out.status.success(),
+        "blame failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let out = String::from_utf8(out.stdout).unwrap();
+
+    // alpha never changed → c1; beta edited → c2; delta added → c3;
+    // gamma2 was renamed in c3 but its BODY is from c1 → blame sees through to c1.
+    assert!(out.contains(&format!("{c1}  fn     alpha")), "got:\n{out}");
+    assert!(out.contains(&format!("{c2}  fn     beta")), "got:\n{out}");
+    assert!(
+        out.contains(&format!("{c1}  fn     gamma2")),
+        "refactor-aware: rename must be seen through; got:\n{out}"
+    );
+    assert!(out.contains(&format!("{c3}  fn     delta")), "got:\n{out}");
+}


### PR DESCRIPTION
## Summary

The **payoff** of node identity. `git-ast blame <file>` reports, per top-level item, the commit that last changed it — **following it through renames**. A renamed function blames to where its *body* was written, **not** the rename commit — exactly what plain `git blame` can't do.

```
17d71ae  fn     alpha    # never changed -> c1
bbb9d39  fn     beta     # body edited   -> c2
17d71ae  fn     gamma2   # renamed in c3, body from c1 -> blames c1 (rename seen through!)
b99b6fc  fn     delta    # added         -> c3
```

Per git-ast's own essay — *identity is computed, not stored; git notes are a transport, not the mechanism* — this needs **no git-notes persistence**: it's **computed on demand** by walking the file's history and matching items commit-to-commit with `match_defs`.

- **`src/blame.rs`** — `blame(file)`: `git log`/`git show` per commit, then for each HEAD item, track it back through history classifying each step (Unchanged → follow; Renamed[body same] → follow *through* the rename; Modified/RenamedEdited → body changed here; Added → introduced here). Reuses `inspect` + `match_defs`.
- **`src/main.rs`** — `git-ast blame <file>` verb.

## Bonus: runs as a git subcommand
Because the binary is named `git-ast`, every command also works as `git ast <command>` (`git ast blame`, `git ast match`, …) via git's subcommand discovery. (README note; verified.)

## Tests — all green (77 unit + blame e2e + 15 cucumber/87 + 2 identity e2e + 5 merge)
- `tests/blame_e2e.rs` builds a real repo (edit / **rename-through** / add) and asserts the attribution, including the rename-seen-through case.

## Out of scope
**Per-line** blame (this is per-definition), persisting attribution across history rewrites (git notes), file-level renames, binding/use-site identity, cross-file.

## Trust ledger
Strengthens **8.1d** (stays 🟡): node identity now powers **refactor-aware blame** — the payoff the whole arc was building toward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)